### PR TITLE
adding gcp enclave tool page

### DIFF
--- a/webroot/adm/enclave-gcp.html
+++ b/webroot/adm/enclave-gcp.html
@@ -1,0 +1,175 @@
+<html>
+<head>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="/js/main.js"></script>
+</head>
+<body>
+<h1>UID2 Admin - GCP Enclave ID Tool</h1>
+
+<a href="/">Back</a>
+
+<br>
+<br>
+
+<h3>Inputs</h3>
+
+<label for="diskUri">GCP Disk URI. To get the latest: gcloud compute images list --filter="name~'cos'" --standard-images --uri</label>
+<br>
+<input type="text" id="diskUri" name="diskUri" size="100" value="">
+<br>
+<br>
+
+<label for="apiToken">Operator Api Token:</label>
+<br>
+<input type="text" id="apiToken" name="apiToken" size="100" value="">
+<br>
+<br>
+
+<label for="imageId">Operator Docker Image ID</label>
+<br>
+<input type="text" id="imageId" name="imageId" size="100" value="">
+<br>
+<br>
+
+<label for="enclaveParams">Enclave Parameters, e.g. API_TOKEN, or API_TOKEN,IMAGE_ID</label>
+<br>
+<input type="text" id="enclaveParams" name="enclaveParams" size="100" value="API_TOKEN">
+<br>
+<br>
+
+<label for="cloudInit">cloud-init</label>
+<br>
+<textarea id="cloudInit" name="cloudInit" rows="40" cols="120">
+#cloud-config
+</textarea>
+<br>
+<br>
+
+<h3>Operations</h3>
+
+<ul>
+    <li><a href="#" id="doGenerate">Generate GCP cloud-init, Enclave ID and gcloud command</a></li>
+</ul>
+<br>
+
+<h3>Outputs</h3>
+
+<label for="cloudInitSha256">cloud-init sha256, make sure your downloaded cloud-init config matches exactly the value below:</label>
+<br>
+<pre><label id="cloudInitSha256">TBD</label></pre>
+<br>
+<br>
+
+<label for="gcloudCli">Example gcloud command to create GCP Operator Enclave VM:</label>
+<br>
+<textarea id="gcloudCli" name="gcloudCli" rows="10" cols="120" readonly>
+</textarea>
+<br>
+<br>
+
+<label for="enclaveId">Generated GCP Enclave ID:</label>
+<br>
+<pre><label id="enclaveId">TBD</label></pre>
+<br>
+<br>
+
+<script language="JavaScript">
+    var gcloudCliOrig = '$ sha256sum < ./<CLOUD_INIT_FN> # !!! check if sha256 matches exactly below !!!\\\n\
+<CLOUD_INIT_MD>\n\
+\n\
+$ gcloud compute instances \\\n\
+    create uid2-operator-gcp-01 \\\n\
+    --confidential-compute \\\n\
+    --maintenance-policy Terminate \\\n\
+    --image <DISK_URI> \\\n\
+    --metadata-from-file user-data=./<CLOUD_INIT_FN> \\\n\
+    --tags http-server'
+
+    $('#gcloudCli').val(gcloudCliOrig);
+
+    function sha256hex(string) {
+      const utf8 = new TextEncoder().encode(string);
+      return crypto.subtle.digest('SHA-256', utf8).then((hashBuffer) => {
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        const hashHex = hashArray
+          .map((bytes) => bytes.toString(16).padStart(2, '0'))
+          .join('');
+        return hashHex;
+      });
+    }
+
+    function sha256base64(string) {
+      const utf8 = new TextEncoder().encode(string);
+      return crypto.subtle.digest('SHA-256', utf8).then((hashBuffer) => {
+        return btoa(String.fromCharCode(...new Uint8Array(hashBuffer)));
+      });
+    }
+
+    function download(filename, text) {
+      var element = document.createElement('a');
+      element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+      element.setAttribute('download', filename);
+
+      element.style.display = 'none';
+      document.body.appendChild(element);
+
+      element.click();
+
+      document.body.removeChild(element);
+    }
+
+    function normalizeCloudInit(text) {
+        return text
+            .replace(/([^\n])$/g, '$1\n')
+            .replace(/\n+$/g, '\n');
+    }
+
+    $(document).ready(function () {
+        $('#doGenerate').on('click', function () {
+            var ts = Math.floor(new Date() / 1000);
+            var fn = 'cloud-init-' + ts + '.yaml';
+            var diskUri = $('#diskUri').val();
+
+            var cloudInit = normalizeCloudInit($('#cloudInit').val());
+            var apiToken = $('#apiToken').val();
+            var imageId = $('#imageId').val();
+            cloudInit = cloudInit
+              .replace(/^([ \t]*Environment=.UID2_ENCLAVE_API_TOKEN)=.+?\"$/gm, '$1=' + apiToken + '"')
+              .replace(/^([ \t]*Environment=.UID2_ENCLAVE_IMAGE_ID)=.+?\"$/gm, '$1=' + imageId + '"');
+
+            download(fn, cloudInit);
+
+            sha256hex(cloudInit).then(hex => {
+              $('#cloudInitSha256').text(hex);
+
+              var cli = gcloudCliOrig
+                  .replaceAll('<CLOUD_INIT_FN>', fn)
+                  .replaceAll('<CLOUD_INIT_MD>', hex)
+                  .replaceAll('<DISK_URI>', diskUri);
+
+              $('#gcloudCli').val(cli);
+            });
+
+            var tplCloudInit = cloudInit;
+            var enclaveParams = $('#enclaveParams').val().toUpperCase().split(',')
+            enclaveParams.forEach(p => {
+              var enclaveParam = "UID2_ENCLAVE_" + p;
+              const reMaskParam = new RegExp('^([ \t]*Environment=.' + enclaveParam + ')=.+?\"$', 'gm');
+              tplCloudInit = tplCloudInit.replace(reMaskParam, '$1=dummy"');
+            });
+
+            $('#cloudInit').val(tplCloudInit);
+
+            sha256base64(diskUri).then(s1 => {
+              sha256base64(tplCloudInit).then(s2 => {
+                sha256base64(s1 + s2).then(enclaveId => {
+                  $('#enclaveId').text(enclaveId);
+                });
+              });
+            });
+        });
+    });
+</script>
+
+</body>
+</html>

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -26,6 +26,7 @@ Logged in as <span id="loginEmail"></span>
     <li class="ro-sem" style="display: none"><a href="/adm/salt.html">Salts Management</a></li>
     <li class="ro-opm ro-adm" style="display: none"><a href="/adm/operator-key.html">Operator Key Management</a></li>
     <li class="ro-opm ro-adm" style="display: none"><a href="/adm/enclave-id.html">Enclave ID Management</a></li>
+    <li class="ro-opm ro-adm" style="display: none"><a href="/adm/enclave-gcp.html">GCP Enclave ID Tool</a></li>
     <li class="ro-adm" style="display: none"><a href="/adm/partner-config.html">OptOut Partner Management</a></li>
     <li class="ro-adm" style="display: none"><a href="/adm/administrators.html">Administrator Management</a></li>
     <li class="ro-nil" style="display: none">No Admin Permissions</li>


### PR DESCRIPTION
This is a static html page without any backend interaction, can be used to generate GCP EnclaveID and gcloud command line for GCP Enclave provisioning.