### PR TITLE
Loki Auditing

### DIFF
--- a/conf/logback-local.loki.xml
+++ b/conf/logback-local.loki.xml
@@ -1,0 +1,46 @@
+<configuration>
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=uid2-admin,host=${HOSTNAME},portoffset=${port_offset:-0},level=%level</pattern>
+            </label>
+            <message>
+                <pattern>l=%level h=${HOSTNAME} po=${port_offset:-0} c=%logger{20} t=%thread | %msg %ex</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
+    <appender name="AUDIT" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://localhost:3200/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=uid2-admin,host=${HOSTNAME},portoffset=${port_offset:-0}</pattern>
+            </label>
+            <message>
+                <pattern>%d{HH:mm:ss.SSS} | %msg</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.uid2.admin.audit" additivity="false">
+        <appender-ref ref="AUDIT"/>
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOKI" />
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/conf/logback.loki.xml
+++ b/conf/logback.loki.xml
@@ -19,10 +19,10 @@
         </http>
         <format>
             <label>
-                <pattern>app=uid2-admin,host=${HOSTNAME},portoffset=${port_offset:-0},level=%level</pattern>
+                <pattern>app=uid2-admin,host=${HOSTNAME},portoffset=${port_offset:-0}</pattern>
             </label>
             <message>
-                <pattern>l=%level h=${HOSTNAME} po=${port_offset:-0} c=%logger{20} t=%thread | %msg %ex</pattern>
+                <pattern>%d{HH:mm:ss.SSS} | %msg</pattern>
             </message>
             <sortByTime>true</sortByTime>
         </format>
@@ -35,9 +35,12 @@
         </encoder>
     </appender>
 
+    <logger name="com.uid2.admin.audit" additivity="false">
+        <appender-ref ref="AUDIT"/>
+    </logger>
+
     <root level="DEBUG">
         <appender-ref ref="LOKI"   />
-        <appender-ref ref="AUDIT"  />
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/conf/logback.loki.xml
+++ b/conf/logback.loki.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>http://localhost:3100/loki/api/v1/push</url>
+            <url>http://loki:3100/loki/api/v1/push</url>
         </http>
         <format>
             <label>

--- a/conf/logback.loki.xml
+++ b/conf/logback.loki.xml
@@ -15,7 +15,7 @@
     </appender>
     <appender name="AUDIT" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>http://localhost:3200/loki/api/v1/push</url>
+            <url>http://loki:3200/loki/api/v1/push</url>
         </http>
         <format>
             <label>
@@ -40,7 +40,7 @@
     </logger>
 
     <root level="DEBUG">
-        <appender-ref ref="LOKI"   />
+        <appender-ref ref="LOKI" />
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/conf/logback.loki.xml
+++ b/conf/logback.loki.xml
@@ -1,7 +1,21 @@
 <configuration>
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>http://loki:3100/loki/api/v1/push</url>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=uid2-admin,host=${HOSTNAME},portoffset=${port_offset:-0},level=%level</pattern>
+            </label>
+            <message>
+                <pattern>l=%level h=${HOSTNAME} po=${port_offset:-0} c=%logger{20} t=%thread | %msg %ex</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
+    <appender name="AUDIT" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://localhost:3200/loki/api/v1/push</url>
         </http>
         <format>
             <label>
@@ -22,7 +36,8 @@
     </appender>
 
     <root level="DEBUG">
-        <appender-ref ref="LOKI" />
+        <appender-ref ref="LOKI"   />
+        <appender-ref ref="AUDIT"  />
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.loki4j</groupId>
+            <artifactId>loki-logback-appender</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.qldb</groupId>
             <artifactId>amazon-qldb-driver-java</artifactId>
             <version>2.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
             <version>1.2.9</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.loki4j</groupId>
             <artifactId>loki-logback-appender</artifactId>
             <version>1.3.2</version>

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class QLDBAuditWriter implements AuditWriter{
     private static final IonSystem ionSys = IonSystemBuilder.standard().build();
     private static final Logger logger = LoggerFactory.getLogger(QLDBAuditWriter.class);
+    private static final Logger auditLogger = LoggerFactory.getLogger("com.uid2.admin.audit");
     private final QldbDriver qldbDriver;
     private final String logTable;
     public QLDBAuditWriter(JsonObject config){
@@ -48,7 +49,6 @@ public class QLDBAuditWriter implements AuditWriter{
             }
         });
 
-        // write to Loki
-        // logger.info(model.writeToString());
+        auditLogger.info(model.writeToString());
     }
 }


### PR DESCRIPTION
In addition to logging to a QLDB, logging to Loki, a highly available logging service, makes it simple to retrieve audit logs in the future, at the cost of the lack of assurance of modification, security, etc. Adding loki auditing is not intended to replace the QLDB, indeed, the QLDB is intended to be the source of truth, and Loki logs are intended to solely be an accessible way to retrieve the same logs. If auditors need the cryptographic proof that the logs are what they should be, then they should access the QLDB instead of Loki.