### PR TITLE
try-catch on qldbDriver initialization

### DIFF
--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -17,15 +17,20 @@ public class QLDBAuditWriter implements AuditWriter{
     private static final IonSystem ionSys = IonSystemBuilder.standard().build();
     private static final Logger logger = LoggerFactory.getLogger(QLDBAuditWriter.class);
     private static final Logger auditLogger = LoggerFactory.getLogger("com.uid2.admin.audit");
-    private final QldbDriver qldbDriver;
+    private QldbDriver qldbDriver;
     private final String logTable;
     private final boolean qldbLogging;
     public QLDBAuditWriter(JsonObject config){
-        qldbDriver = QldbDriver.builder()
-                .ledger(config.getString("qldb_ledger_name"))
-                .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
-                .sessionClientBuilder(QldbSessionClient.builder())
-                .build();
+        try {
+            qldbDriver = QldbDriver.builder()
+                    .ledger(config.getString("qldb_ledger_name"))
+                    .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
+                    .sessionClientBuilder(QldbSessionClient.builder())
+                    .build();
+        }
+        catch (Exception e){
+            logger.error("failed to establish connection with qldb");
+        }
         logTable = config.getString("qldb_table_name");
         qldbLogging = config.getBoolean("enable_qldb_admin_logging");
     }

--- a/src/main/java/com/uid2/admin/audit/QLDBInit.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBInit.java
@@ -24,26 +24,31 @@ public class QLDBInit {
     private static final Logger LOGGER = LoggerFactory.getLogger(QLDBInit.class);
 
     public static void init(List<IService> services, JsonObject config) {
-        qldbDriver = QldbDriver.builder()
-                .ledger(config.getString("qldb_ledger_name"))
-                .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
-                .sessionClientBuilder(QldbSessionClient.builder())
-                .build();
-        qldbTableName = config.getString("qldb_table_name");
-        if (!hasTableBeenCreated()) {
-            createTable();
-        }
-        for (IService service : services) {
-            if (!isServiceSetup(service)) {
-                Collection<OperationModel> modelList = service.qldbSetup();
-                insertIntoQLDB(new OperationModel(service.tableType(), Constants.DEFAULT_ITEM_KEY,
-                        null, null, null));
-                for (OperationModel model : modelList) {
-                    insertIntoQLDB(model);
+        try {
+            qldbDriver = QldbDriver.builder()
+                    .ledger(config.getString("qldb_ledger_name"))
+                    .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
+                    .sessionClientBuilder(QldbSessionClient.builder())
+                    .build();
+            qldbTableName = config.getString("qldb_table_name");
+            if (!hasTableBeenCreated()) {
+                createTable();
+            }
+            for (IService service : services) {
+                if (!isServiceSetup(service)) {
+                    Collection<OperationModel> modelList = service.qldbSetup();
+                    insertIntoQLDB(new OperationModel(service.tableType(), Constants.DEFAULT_ITEM_KEY,
+                            null, null, null));
+                    for (OperationModel model : modelList) {
+                        insertIntoQLDB(model);
+                    }
                 }
             }
+            LOGGER.info("initialized qldb");
         }
-        LOGGER.info("initialized qldb");
+        catch(Exception e){
+            LOGGER.warn("failed to initialize qldb");
+        }
     }
 
     private static boolean hasTableBeenCreated() {


### PR DESCRIPTION
This change is intended to prevent the pod from immediately crashing out if it cannot connect to the qldb due to misconfiguration