### PR TITLE
Failure-safe Admin Logging

### DIFF
--- a/conf/default-config.json
+++ b/conf/default-config.json
@@ -1,5 +1,5 @@
 {
   "enable_qldb_admin_logging": true,
   "qldb_ledger_name": "uid2-audit-logs",
-  "qldb_table_name": "logs"
+  "qldb_table_name": "admin_logs"
 }

--- a/conf/default-config.json
+++ b/conf/default-config.json
@@ -1,4 +1,5 @@
 {
+  "enable_admin_logging": false,
   "qldb_ledger_name": "uid2-audit-logs",
   "qldb_table_name": "logs"
 }

--- a/conf/default-config.json
+++ b/conf/default-config.json
@@ -1,5 +1,5 @@
 {
-  "enable_admin_logging": false,
+  "enable_qldb_admin_logging": true,
   "qldb_ledger_name": "uid2-audit-logs",
   "qldb_table_name": "logs"
 }

--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -1,5 +1,5 @@
 {
-  "enable_admin_logging": true,
+  "enable_admin_logging": false,
   "qldb_ledger_name": "audit-logs",
   "qldb_table_name": "logs"
 }

--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -1,4 +1,5 @@
 {
+  "enable_admin_logging": true,
   "qldb_ledger_name": "audit-logs",
   "qldb_table_name": "logs"
 }

--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -1,5 +1,5 @@
 {
-  "enable_admin_logging": false,
+  "enable_qldb_admin_logging": false,
   "qldb_ledger_name": "audit-logs",
   "qldb_table_name": "logs"
 }

--- a/conf/logback.loki.xml
+++ b/conf/logback.loki.xml
@@ -15,11 +15,11 @@
     </appender>
     <appender name="AUDIT" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>http://loki:3200/loki/api/v1/push</url>
+            <url>http://loki:3100/loki/api/v1/push</url>
         </http>
         <format>
             <label>
-                <pattern>app=uid2-admin,host=${HOSTNAME},portoffset=${port_offset:-0}</pattern>
+                <pattern>app=uid2-admin-audit,host=${HOSTNAME},portoffset=${port_offset:-0}</pattern>
             </label>
             <message>
                 <pattern>%d{HH:mm:ss.SSS} | %msg</pattern>

--- a/conf/logback.loki.xml
+++ b/conf/logback.loki.xml
@@ -1,7 +1,21 @@
 <configuration>
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>http://loki:3100/loki/api/v1/push</url>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=uid2-admin,host=${HOSTNAME},portoffset=${port_offset:-0},level=%level</pattern>
+            </label>
+            <message>
+                <pattern>l=%level h=${HOSTNAME} po=${port_offset:-0} c=%logger{20} t=%thread | %msg %ex</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
+    <appender name="AUDIT" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://localhost:3200/loki/api/v1/push</url>
         </http>
         <format>
             <label>
@@ -22,7 +36,8 @@
     </appender>
 
     <root level="DEBUG">
-        <appender-ref ref="LOKI" />
+        <appender-ref ref="LOKI"   />
+        <appender-ref ref="AUDIT"  />
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-admin</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.26</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>1.2.9</version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.loki4j</groupId>
+            <artifactId>loki-logback-appender</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.qldb</groupId>
             <artifactId>amazon-qldb-driver-java</artifactId>
             <version>2.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,21 +90,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>1.2.9</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.9</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.loki4j</groupId>
-            <artifactId>loki-logback-appender</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.qldb</groupId>
             <artifactId>amazon-qldb-driver-java</artifactId>
             <version>2.3.1</version>

--- a/src/main/java/com/uid2/admin/Constants.java
+++ b/src/main/java/com/uid2/admin/Constants.java
@@ -1,8 +1,5 @@
 package com.uid2.admin;
 
-import com.uid2.admin.audit.Type;
-import com.uid2.admin.vertx.service.IService;
-
 public class Constants {
     public static final String DEFAULT_ITEM_KEY = "$all_items&"; //needs to be unlikely to be a name of a current or future user
 }

--- a/src/main/java/com/uid2/admin/Constants.java
+++ b/src/main/java/com/uid2/admin/Constants.java
@@ -1,5 +1,8 @@
 package com.uid2.admin;
 
+import com.uid2.admin.audit.Type;
+import com.uid2.admin.vertx.service.IService;
+
 public class Constants {
     public static final String DEFAULT_ITEM_KEY = "$all_items&"; //needs to be unlikely to be a name of a current or future user
 }

--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -23,8 +23,9 @@
 
 package com.uid2.admin;
 
+import com.uid2.admin.audit.AdminQLDBInit;
 import com.uid2.admin.audit.AuditFactory;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.QLDBInit;
 import com.uid2.admin.auth.*;
 import com.uid2.admin.secret.IKeyGenerator;
@@ -124,7 +125,7 @@ public class Main {
             RotatingPartnerStore partnerConfigProvider = new RotatingPartnerStore(cloudStorage, partnerMetadataPath);
             partnerConfigProvider.loadContent();
 
-            AuditMiddleware audit = AuditFactory.getAuditMiddleware(config);
+            IAuditMiddleware audit = AuditFactory.getAuditMiddleware(config);
             AuthMiddleware auth = new AuthMiddleware(adminUserProvider);
             WriteLock writeLock = new WriteLock();
             IKeyGenerator keyGenerator = new SecureKeyGenerator();
@@ -154,7 +155,8 @@ public class Main {
             AdminVerticle adminVerticle = new AdminVerticle(authHandlerFactory, auth, adminUserProvider,
                     services);
 
-            QLDBInit.init(services, config);
+            AdminQLDBInit init = new AdminQLDBInit(config);
+            init.init(services);
 
             RotatingStoreVerticle rotatingAdminUserStoreVerticle = new RotatingStoreVerticle(
                     "admins", 10000, adminUserProvider);

--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -25,7 +25,6 @@ package com.uid2.admin;
 
 import com.uid2.admin.audit.AuditFactory;
 import com.uid2.admin.audit.AuditMiddleware;
-import com.uid2.admin.audit.AuditMiddlewareImpl;
 import com.uid2.admin.audit.QLDBInit;
 import com.uid2.admin.auth.*;
 import com.uid2.admin.secret.IKeyGenerator;

--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -25,7 +25,6 @@ package com.uid2.admin;
 
 import com.uid2.admin.audit.AuditFactory;
 import com.uid2.admin.audit.AuditMiddleware;
-import com.uid2.admin.audit.QLDBAuditMiddleware;
 import com.uid2.admin.auth.*;
 import com.uid2.admin.secret.IKeyGenerator;
 import com.uid2.admin.secret.ISaltRotation;
@@ -124,8 +123,7 @@ public class Main {
             RotatingPartnerStore partnerConfigProvider = new RotatingPartnerStore(cloudStorage, partnerMetadataPath);
             partnerConfigProvider.loadContent();
 
-            AuditFactory.setConfig(config);
-            AuditMiddleware audit = AuditFactory.getAuditMiddleware(Main.class);
+            AuditMiddleware audit = AuditFactory.getAuditMiddleware(config);
             AuthMiddleware auth = new AuthMiddleware(adminUserProvider);
             WriteLock writeLock = new WriteLock();
             IKeyGenerator keyGenerator = new SecureKeyGenerator();

--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -25,6 +25,8 @@ package com.uid2.admin;
 
 import com.uid2.admin.audit.AuditFactory;
 import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.AuditMiddlewareImpl;
+import com.uid2.admin.audit.QLDBInit;
 import com.uid2.admin.auth.*;
 import com.uid2.admin.secret.IKeyGenerator;
 import com.uid2.admin.secret.ISaltRotation;
@@ -152,6 +154,8 @@ public class Main {
 
             AdminVerticle adminVerticle = new AdminVerticle(authHandlerFactory, auth, adminUserProvider,
                     services);
+
+            QLDBInit.init(services, config);
 
             RotatingStoreVerticle rotatingAdminUserStoreVerticle = new RotatingStoreVerticle(
                     "admins", 10000, adminUserProvider);

--- a/src/main/java/com/uid2/admin/audit/AdminQLDBInit.java
+++ b/src/main/java/com/uid2/admin/audit/AdminQLDBInit.java
@@ -37,9 +37,9 @@ public class AdminQLDBInit extends QLDBInit{
                         null, null, null));
                 totalModelList.add(new OperationModel(service.tableType(), Constants.NULL_ITEM_KEY,
                         null, null, null));
-                init(totalModelList);
             }
         }
+        init(totalModelList);
     }
 
     private boolean isServiceSetup(IService service) {
@@ -47,7 +47,7 @@ public class AdminQLDBInit extends QLDBInit{
             final IonStruct[] count = new IonStruct[1];
             qldbDriver.execute(txn -> {
                 Result result = txn.execute("SELECT COUNT(*) AS \"count\" FROM " + qldbTableName
-                        + " AS t WHERE t.data.itemType = ?", ionSys.newString(service.tableType().toString()));
+                        + " AS t WHERE t.itemType = ?", ionSys.newString(service.tableType().toString()));
                 count[0] = (IonStruct) result.iterator().next();
             });
             return !count[0].get("count").equals(ionSys.newInt(0));

--- a/src/main/java/com/uid2/admin/audit/AdminQLDBInit.java
+++ b/src/main/java/com/uid2/admin/audit/AdminQLDBInit.java
@@ -1,0 +1,58 @@
+package com.uid2.admin.audit;
+
+import com.amazon.ion.IonStruct;
+import com.uid2.admin.Constants;
+import com.uid2.admin.vertx.service.IService;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import software.amazon.awssdk.services.qldbsession.QldbSessionClient;
+import software.amazon.qldb.QldbDriver;
+import software.amazon.qldb.Result;
+import software.amazon.qldb.RetryPolicy;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+public class AdminQLDBInit extends QLDBInit{
+    private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+
+    public AdminQLDBInit(JsonObject config){
+        qldbDriver = QldbDriver.builder()
+                .ledger(config.getString("qldb_ledger_name"))
+                .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
+                .sessionClientBuilder(QldbSessionClient.builder())
+                .build();
+        qldbTableName = config.getString("qldb_table_name");
+    }
+
+    public void init(List<IService> services) {
+        Collection<OperationModel> totalModelList = new HashSet<>();
+        for (IService service : services) {
+            if (!hasTableBeenCreated() || !isServiceSetup(service)) {
+                totalModelList.addAll(service.qldbSetup());
+                totalModelList.add(new OperationModel(service.tableType(), Constants.DEFAULT_ITEM_KEY,
+                        null, null, null));
+                totalModelList.add(new OperationModel(service.tableType(), Constants.NULL_ITEM_KEY,
+                        null, null, null));
+                init(totalModelList);
+            }
+        }
+    }
+
+    private boolean isServiceSetup(IService service) {
+        try {
+            final IonStruct[] count = new IonStruct[1];
+            qldbDriver.execute(txn -> {
+                Result result = txn.execute("SELECT COUNT(*) AS \"count\" FROM " + qldbTableName
+                        + " AS t WHERE t.data.itemType = ?", ionSys.newString(service.tableType().toString()));
+                count[0] = (IonStruct) result.iterator().next();
+            });
+            return !count[0].get("count").equals(ionSys.newInt(0));
+        } catch (Exception e) {
+            throw new RuntimeException("AWS configuration not set up");
+        }
+    }
+}

--- a/src/main/java/com/uid2/admin/audit/AuditFactory.java
+++ b/src/main/java/com/uid2/admin/audit/AuditFactory.java
@@ -1,8 +1,6 @@
 package com.uid2.admin.audit;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,10 +14,10 @@ import java.util.Map;
  */
 public class AuditFactory {
     private static final Map<JsonObject, AuditMiddleware> middlewareMap = new HashMap<>();
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuditFactory.class);
 
     /**
-     * Returns an AuditMiddleware object for the designated class to use.
+     * Returns an AuditMiddleware object with the designated configuration. If one does
+     * not already exist, creates a new AuditMiddleware object using the configuration.
      *
      * @return the designated AuditMiddleware object for the passed class.
      */

--- a/src/main/java/com/uid2/admin/audit/AuditFactory.java
+++ b/src/main/java/com/uid2/admin/audit/AuditFactory.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * exhibit some other behavior.
  */
 public class AuditFactory {
-    private static final Map<JsonObject, AuditMiddleware> middlewareMap = new HashMap<>();
+    private static final Map<JsonObject, IAuditMiddleware> middlewareMap = new HashMap<>();
 
     /**
      * Returns an AuditMiddleware object with the designated configuration. If one does
@@ -21,7 +21,7 @@ public class AuditFactory {
      *
      * @return the designated AuditMiddleware object for the passed class.
      */
-    public static AuditMiddleware getAuditMiddleware(JsonObject config){
+    public static IAuditMiddleware getAuditMiddleware(JsonObject config){
         if(!middlewareMap.containsKey(config)){
             middlewareMap.put(config, new AuditMiddlewareImpl(new QLDBAuditWriter(config)));
         }

--- a/src/main/java/com/uid2/admin/audit/AuditFactory.java
+++ b/src/main/java/com/uid2/admin/audit/AuditFactory.java
@@ -4,6 +4,9 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * AuditFactory controls the instantiation/creation of AuditMiddleware objects.
  * Depending on the needs of the specific implementation, the AuditFactory
@@ -12,26 +15,19 @@ import io.vertx.core.logging.LoggerFactory;
  * exhibit some other behavior.
  */
 public class AuditFactory {
-    public static AuditWriter auditWriter;
-    private static AuditMiddleware auditMiddleware;
+    private static final Map<JsonObject, AuditMiddleware> middlewareMap = new HashMap<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(AuditFactory.class);
 
     /**
      * Returns an AuditMiddleware object for the designated class to use.
      *
-     * @param clazz the class that requires an AuditMiddleware object.
      * @return the designated AuditMiddleware object for the passed class.
      */
-    public static AuditMiddleware getAuditMiddleware(Class<?> clazz){
-        if(auditMiddleware == null){
-            LOGGER.fatal("setConfig not called before getAuditMiddleware in class AuditFactory");
-            throw new IllegalStateException("setConfig not called before getAuditMiddleware in class AuditFactory");
+    public static AuditMiddleware getAuditMiddleware(JsonObject config){
+        if(!middlewareMap.containsKey(config)){
+            middlewareMap.put(config, new AuditMiddlewareImpl(new QLDBAuditWriter(config), config));
         }
-        return auditMiddleware;
+        return middlewareMap.get(config);
     }
 
-    public static void setConfig(JsonObject config){
-        auditWriter = new QLDBAuditWriter(config);
-        auditMiddleware = new QLDBAuditMiddleware(auditWriter);
-    }
 }

--- a/src/main/java/com/uid2/admin/audit/AuditMiddlewareImpl.java
+++ b/src/main/java/com/uid2/admin/audit/AuditMiddlewareImpl.java
@@ -1,40 +1,42 @@
 package com.uid2.admin.audit;
 
-import com.uid2.admin.Constants;
-import com.uid2.admin.vertx.service.IService;
 import com.uid2.shared.auth.IAuthorizable;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
 import java.time.Instant;
-import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
-public class QLDBAuditMiddleware implements AuditMiddleware{
+public class AuditMiddlewareImpl implements AuditMiddleware{
     private final AuditWriter auditWriter;
+    private final JsonObject config;
 
-    protected QLDBAuditMiddleware(AuditWriter writer){
+    protected AuditMiddlewareImpl(AuditWriter writer, JsonObject config){
         this.auditWriter = writer;
+        this.config = config;
     }
 
     @Override
     public Handler<RoutingContext> handle(Function<RoutingContext, List<OperationModel>> handler) {
-        InnerAuditHandler auditHandler = new InnerAuditHandler(handler, auditWriter);
+        InnerAuditHandler auditHandler = new InnerAuditHandler(handler, auditWriter, config.getBoolean("enable_admin_logging"));
         return auditHandler::writeLog;
     }
 
     private static class InnerAuditHandler{
         private final Function<RoutingContext, List<OperationModel>> innerHandler;
         private final AuditWriter auditWriter;
-        private InnerAuditHandler(Function<RoutingContext, List<OperationModel>> handler, AuditWriter auditWriter) {
+        private final boolean auditingEnabled;
+        private InnerAuditHandler(Function<RoutingContext, List<OperationModel>> handler, AuditWriter auditWriter, boolean auditingEnabled) {
             this.innerHandler = handler;
             this.auditWriter = auditWriter;
+            this.auditingEnabled = auditingEnabled;
         }
 
         public void writeLog(RoutingContext rc){
             List<OperationModel> modelList = innerHandler.apply(rc);
-            if(modelList != null){
+            if(auditingEnabled && modelList != null){
                 String ipAddress = getIPAddress(rc);
                 for(OperationModel model : modelList) {
                     AuditModel auditModel = new QLDBAuditModel(model.itemType, model.itemKey, model.actionTaken, ipAddress,

--- a/src/main/java/com/uid2/admin/audit/AuditMiddlewareImpl.java
+++ b/src/main/java/com/uid2/admin/audit/AuditMiddlewareImpl.java
@@ -10,10 +10,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-public class AuditMiddlewareImpl implements AuditMiddleware{
-    private final AuditWriter auditWriter;
+public class AuditMiddlewareImpl implements IAuditMiddleware{
+    private final IAuditWriter auditWriter;
 
-    public AuditMiddlewareImpl(AuditWriter writer){
+    public AuditMiddlewareImpl(IAuditWriter writer){
         this.auditWriter = writer;
     }
 
@@ -25,15 +25,15 @@ public class AuditMiddlewareImpl implements AuditMiddleware{
 
     private static class InnerAuditHandler{
         private final RoutingContext rc;
-        private final AuditWriter auditWriter;
-        private InnerAuditHandler(RoutingContext rc, AuditWriter auditWriter) {
+        private final IAuditWriter auditWriter;
+        private InnerAuditHandler(RoutingContext rc, IAuditWriter auditWriter) {
             this.rc = rc;
             this.auditWriter = auditWriter;
         }
 
         public boolean writeLogs(List<OperationModel> modelList){
             String ipAddress = getIPAddress(rc);
-            List<AuditModel> auditModelList = new ArrayList<>();
+            List<IAuditModel> auditModelList = new ArrayList<>();
             for(OperationModel model : modelList) {
                 auditModelList.add(new QLDBAuditModel(model.itemType, model.itemKey, model.actionTaken, ipAddress,
                         rc != null ? ((IAuthorizable) rc.data().get("api-client")).getContact() : null,

--- a/src/main/java/com/uid2/admin/audit/IAuditInit.java
+++ b/src/main/java/com/uid2/admin/audit/IAuditInit.java
@@ -1,0 +1,16 @@
+package com.uid2.admin.audit;
+
+import java.util.Collection;
+
+/**
+ * Responsible for the initialization of the QLDB table and any initial entries it must contain.
+ */
+public interface IAuditInit {
+
+    /**
+     * Creates a table with the name specified in the config, with all entries as specified by modelList, and sets up
+     * any necessary configuration.
+     * @param modelList the models to add to the audit database.
+     */
+    void init(Collection<OperationModel> modelList);
+}

--- a/src/main/java/com/uid2/admin/audit/IAuditMiddleware.java
+++ b/src/main/java/com/uid2/admin/audit/IAuditMiddleware.java
@@ -1,7 +1,5 @@
 package com.uid2.admin.audit;
 
-import com.uid2.admin.vertx.service.IService;
-import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
 import java.util.List;
@@ -11,15 +9,14 @@ import java.util.function.Function;
  * AuditMiddleware objects are intended to be attached to any endpoint that the system
  * wants to keep track of via logging to an external source, and pass logging data to an AuditWriter object.
  */
-public interface AuditMiddleware {
+public interface IAuditMiddleware {
 
     /**
      * Handle to attach to any route whose actions require logging.
      *
-     * @param handler the method that performs the action that requires logging,
-     *                converted into {@literal Handler<RoutingContext>} via SAM
-     * @return a new method that logs in addition to executing the method
-     * specified in handler.
+     * @param rc the RoutingContext of the endpoint access that initiated the request.
+     * @return a function that takes a List of OperationModels and returns whether or not the audit
+     * writing was successful.
      */
     Function<List<OperationModel>, Boolean> handle(RoutingContext rc);
 }

--- a/src/main/java/com/uid2/admin/audit/IAuditModel.java
+++ b/src/main/java/com/uid2/admin/audit/IAuditModel.java
@@ -15,7 +15,7 @@ import io.vertx.core.json.JsonObject;
  * • from where was it initiated?
  * • to where was it going?
  */
-public interface AuditModel {
+public interface IAuditModel {
 
     /**
      * Converts the AuditModel to JSON format to be used in document-store databases.

--- a/src/main/java/com/uid2/admin/audit/IAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/IAuditWriter.java
@@ -5,12 +5,12 @@ import java.util.Collection;
 /**
  * AuditWriter is responsible for the logic to write out to designated logging databases.
  */
-public interface AuditWriter {
+public interface IAuditWriter {
     /**
      * Logs the information in the AuditModel to an external database(s).
      * Does not log any information if model == null.
      *
      * @param model the AuditModel to write out.
      */
-    boolean writeLogs(Collection<AuditModel> model);
+    boolean writeLogs(Collection<IAuditModel> model);
 }

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditModel.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditModel.java
@@ -1,5 +1,6 @@
 package com.uid2.admin.audit;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.vertx.core.json.JsonObject;
@@ -9,11 +10,13 @@ public class QLDBAuditModel implements IAuditModel{
     /**
      * The table that the user accesses.
      */
+    @JsonIgnore
     public final Type itemType;
     /**
      * An identifier for the row in the table that is accessed. Is null if more than one row is accessed at the same
      * time, e.g. listing all values in a table. If itemKey should be secret, hash before putting it into the model.
      */
+    @JsonIgnore
     public final String itemKey;
     /**
      * Describes the action the user performed on the table (e.g. read ("GET"), write ("CREATE"/"DELETE")...)
@@ -63,8 +66,6 @@ public class QLDBAuditModel implements IAuditModel{
     public JsonObject writeToJson() {
         Gson gson = new GsonBuilder().serializeNulls().create();
         JsonObject jo = new JsonObject(gson.toJson(this));
-        jo.remove("itemType");
-        jo.remove("itemKey");
         JsonObject outerJo = new JsonObject();
         outerJo.put("itemType", itemType);
         outerJo.put("itemKey", itemKey);

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditModel.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditModel.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.vertx.core.json.JsonObject;
 
-public class QLDBAuditModel implements AuditModel{
+public class QLDBAuditModel implements IAuditModel{
 
     /**
      * The table that the user accesses.

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditModel.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditModel.java
@@ -1,9 +1,12 @@
 package com.uid2.admin.audit;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.vertx.core.json.JsonObject;
+
+import java.io.IOException;
 
 public class QLDBAuditModel implements IAuditModel{
 
@@ -64,8 +67,15 @@ public class QLDBAuditModel implements IAuditModel{
 
     @Override
     public JsonObject writeToJson() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        JsonObject jo = new JsonObject(gson.toJson(this));
+        ObjectMapper mapper = new ObjectMapper();
+        JsonObject jo;
+        try {
+            jo = new JsonObject(mapper.writeValueAsString(this));
+        }
+        catch(IOException e){
+            e.printStackTrace();
+            jo = new JsonObject();
+        }
         JsonObject outerJo = new JsonObject();
         outerJo.put("itemType", itemType);
         outerJo.put("itemKey", itemKey);

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -36,7 +36,7 @@ public class QLDBAuditWriter implements AuditWriter{
             return;
         }
         try {
-            if(qldbLogging) {
+            if (qldbLogging) {
                 qldbDriver.execute(txn -> {
                     List<IonValue> sanitizedInputs = new ArrayList<>();
                     JsonObject jsonObject = model.writeToJson();
@@ -52,6 +52,7 @@ public class QLDBAuditWriter implements AuditWriter{
                     }
                 });
             }
+        }
         catch(Exception e){
             logger.warn("QLDB log failed");
             auditLogger.warn("QLDB log failed");

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -34,21 +34,26 @@ public class QLDBAuditWriter implements AuditWriter{
             return;
         }
         // write to QLDB; update this to UPDATE in one command instead of two
-        qldbDriver.execute(txn -> {
-            List<IonValue> sanitizedInputs = new ArrayList<>();
-            JsonObject jsonObject = model.writeToJson();
-            StringBuilder query = new StringBuilder("UPDATE " + logTable + " AS t SET data = ?");
-            sanitizedInputs.add(ionSys.newLoader().load(jsonObject.toString()).get(0));
-            query.append(" WHERE t.data.itemType = ? AND t.data.itemKey = ?");
-            sanitizedInputs.add(ionSys.newString(jsonObject.getString("itemType")));
-            sanitizedInputs.add(ionSys.newString(jsonObject.getString("itemKey")));
+        try {
+            qldbDriver.execute(txn -> {
+                List<IonValue> sanitizedInputs = new ArrayList<>();
+                JsonObject jsonObject = model.writeToJson();
+                StringBuilder query = new StringBuilder("UPDATE " + logTable + " AS t SET data = ?");
+                sanitizedInputs.add(ionSys.newLoader().load(jsonObject.toString()).get(0));
+                query.append(" WHERE t.data.itemType = ? AND t.data.itemKey = ?");
+                sanitizedInputs.add(ionSys.newString(jsonObject.getString("itemType")));
+                sanitizedInputs.add(ionSys.newString(jsonObject.getString("itemKey")));
 
-            Result r = txn.execute(query.toString(), sanitizedInputs);
-            if(!r.iterator().hasNext()){
-                logger.warn("Malformed audit log input: no log written to QLDB");
-            }
-        });
-
+                Result r = txn.execute(query.toString(), sanitizedInputs);
+                if (!r.iterator().hasNext()) {
+                    logger.warn("Malformed audit log input: no log written to QLDB");
+                }
+            });
+        }
+        catch(Exception e){
+            logger.warn("QLDB log failed");
+            auditLogger.warn("QLDB log failed");
+        }
         auditLogger.info(model.writeToString());
     }
 }

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -54,8 +54,8 @@ public class QLDBAuditWriter implements AuditWriter{
             }
         }
         catch(Exception e){
-            logger.warn("QLDB log failed");
-            auditLogger.warn("QLDB log failed");
+            logger.warn("QLDB log failed: " + e.getClass().getSimpleName());
+            auditLogger.warn("QLDB log failed" + e.getClass().getSimpleName());
         }
         auditLogger.info(model.writeToString());
     }

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -56,8 +56,8 @@ public class QLDBAuditWriter implements IAuditWriter{
                             query = "INSERT INTO " + logTable + " VALUE ?";
                             sanitizedInputs.add(ionSys.newLoader().load(jsonObject.toString()).get(0));
                         } else {
-                            query = "UPDATE " + logTable + " AS t SET data = ? WHERE t.data.itemType = ? AND t.data.itemKey = ?";
-                            sanitizedInputs.add(ionSys.newLoader().load(jsonObject.toString()).get(0));
+                            query = "UPDATE " + logTable + " AS t SET data = ? WHERE t.itemType = ? AND t.itemKey = ?";
+                            sanitizedInputs.add(ionSys.newLoader().load(jsonObject.getJsonObject("data").toString()).get(0));
                             sanitizedInputs.add(ionSys.newString(qldbModel.itemType.toString()));
                             sanitizedInputs.add(ionSys.newString(qldbModel.itemKey));
                         }

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -14,7 +14,7 @@ import software.amazon.qldb.RetryPolicy;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class QLDBAuditWriter implements AuditWriter{
+public class QLDBAuditWriter implements IAuditWriter{
     private static final IonSystem ionSys = IonSystemBuilder.standard().build();
     private static final Logger logger = LoggerFactory.getLogger(QLDBAuditWriter.class);
     private static final Logger auditLogger = LoggerFactory.getLogger("com.uid2.admin.audit");
@@ -36,12 +36,12 @@ public class QLDBAuditWriter implements AuditWriter{
         qldbLogging = config.getBoolean("enable_qldb_admin_logging");
     }
     @Override
-    public boolean writeLogs(Collection<AuditModel> models) {
+    public boolean writeLogs(Collection<IAuditModel> models) {
         AtomicBoolean successfulLog = new AtomicBoolean(true);
         try {
             if (qldbLogging) {
                 qldbDriver.execute(txn -> {
-                    for(AuditModel model : models){
+                    for(IAuditModel model : models){
                         if(!(model instanceof QLDBAuditModel)){ //should never be true, but check in case
                             successfulLog.set(false);
                             logger.error("Only QLDBAuditModel should be passed into QLDBAuditWriter");
@@ -74,7 +74,7 @@ public class QLDBAuditWriter implements AuditWriter{
                 });
             }
             if(successfulLog.get()) {
-                for (AuditModel model : models) {
+                for (IAuditModel model : models) {
                     auditLogger.info(model.writeToString());
                 }
             }

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -1,10 +1,8 @@
 package com.uid2.admin.audit;
 
-import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonSystemBuilder;
-import com.uid2.admin.Constants;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -17,15 +17,20 @@ public class QLDBAuditWriter implements AuditWriter{
     private static final IonSystem ionSys = IonSystemBuilder.standard().build();
     private static final Logger logger = LoggerFactory.getLogger(QLDBAuditWriter.class);
     private static final Logger auditLogger = LoggerFactory.getLogger("com.uid2.admin.audit");
-    private final QldbDriver qldbDriver;
+    private QldbDriver qldbDriver;
     private final String logTable;
     private final boolean qldbLogging;
     public QLDBAuditWriter(JsonObject config){
-        qldbDriver = QldbDriver.builder()
-                .ledger(config.getString("qldb_ledger_name"))
-                .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
-                .sessionClientBuilder(QldbSessionClient.builder())
-                .build();
+        try {
+            qldbDriver = QldbDriver.builder()
+                    .ledger(config.getString("qldb_ledger_name"))
+                    .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
+                    .sessionClientBuilder(QldbSessionClient.builder())
+                    .build();
+        }
+        catch (Exception e){
+            logger.error("failed to establish connection with qldb");
+        }
         logTable = config.getString("qldb_table_name");
         qldbLogging = config.getBoolean("enable_qldb_admin_logging");
     }

--- a/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBAuditWriter.java
@@ -38,11 +38,11 @@ public class QLDBAuditWriter implements IAuditWriter{
     @Override
     public boolean writeLogs(Collection<IAuditModel> models) {
         AtomicBoolean successfulLog = new AtomicBoolean(true);
-        try {
-            if (qldbLogging) {
+        if (qldbLogging) {
+            try {
                 qldbDriver.execute(txn -> {
-                    for(IAuditModel model : models){
-                        if(!(model instanceof QLDBAuditModel)){ //should never be true, but check in case
+                    for (IAuditModel model : models) {
+                        if (!(model instanceof QLDBAuditModel)) { //should never be true, but check in case
                             successfulLog.set(false);
                             logger.error("Only QLDBAuditModel should be passed into QLDBAuditWriter");
                             txn.abort();
@@ -52,12 +52,10 @@ public class QLDBAuditWriter implements IAuditWriter{
                         JsonObject jsonObject = qldbModel.writeToJson();
                         String query;
                         List<IonValue> sanitizedInputs = new ArrayList<>();
-                        if(qldbModel.actionTaken == Actions.CREATE){
+                        if (qldbModel.actionTaken == Actions.CREATE) {
                             query = "INSERT INTO " + logTable + " VALUE ?";
-                            JsonObject wrapped = new JsonObject().put("data", jsonObject);
-                            sanitizedInputs.add(ionSys.newLoader().load(wrapped.toString()).get(0));
-                        }
-                        else{
+                            sanitizedInputs.add(ionSys.newLoader().load(jsonObject.toString()).get(0));
+                        } else {
                             query = "UPDATE " + logTable + " AS t SET data = ? WHERE t.data.itemType = ? AND t.data.itemKey = ?";
                             sanitizedInputs.add(ionSys.newLoader().load(jsonObject.toString()).get(0));
                             sanitizedInputs.add(ionSys.newString(qldbModel.itemType.toString()));
@@ -72,18 +70,18 @@ public class QLDBAuditWriter implements IAuditWriter{
                         }
                     }
                 });
+
+            } catch (Exception e) {
+                logger.error("QLDB log failed: " + e.getClass().getSimpleName());
+                auditLogger.error("QLDB log failed" + e.getClass().getSimpleName());
+                return false;
             }
-            if(successfulLog.get()) {
-                for (IAuditModel model : models) {
-                    auditLogger.info(model.writeToString());
-                }
+        }
+        if (successfulLog.get()) {
+            for (IAuditModel model : models) {
+                auditLogger.info(model.writeToString());
             }
-            return successfulLog.get();
         }
-        catch(Exception e){
-            logger.error("QLDB log failed: " + e.getClass().getSimpleName());
-            auditLogger.error("QLDB log failed" + e.getClass().getSimpleName());
-            return false;
-        }
+        return successfulLog.get();
     }
 }

--- a/src/main/java/com/uid2/admin/audit/QLDBInit.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBInit.java
@@ -99,8 +99,6 @@ public abstract class QLDBInit implements IAuditInit{
         QLDBAuditModel auditModel = new QLDBAuditModel(model.itemType, model.itemKey, model.actionTaken, null,
                 null, null, -1, model.itemHash, model.summary);
         qldbDriver.execute(txn -> {
-            JsonObject jsonObject = new JsonObject();
-            jsonObject.put("data", auditModel.writeToJson());
             txn.execute("INSERT INTO " + qldbTableName + " VALUE ?",
                     ionSys.newLoader().load(auditModel.writeToJson().toString()).get(0));
         });

--- a/src/main/java/com/uid2/admin/audit/QLDBInit.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBInit.java
@@ -24,26 +24,31 @@ public class QLDBInit {
     private static final Logger LOGGER = LoggerFactory.getLogger(QLDBInit.class);
 
     public static void init(List<IService> services, JsonObject config) {
-        qldbDriver = QldbDriver.builder()
-                .ledger(config.getString("qldb_ledger_name"))
-                .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
-                .sessionClientBuilder(QldbSessionClient.builder())
-                .build();
-        qldbTableName = config.getString("qldb_table_name");
-        if (!hasTableBeenCreated()) {
-            createTable();
-        }
-        for (IService service : services) {
-            if (!isServiceSetup(service)) {
-                Collection<OperationModel> modelList = service.qldbSetup();
-                insertIntoQLDB(new OperationModel(service.tableType(), Constants.DEFAULT_ITEM_KEY,
-                        null, null, null));
-                for (OperationModel model : modelList) {
-                    insertIntoQLDB(model);
+        try {
+            qldbDriver = QldbDriver.builder()
+                    .ledger(config.getString("qldb_ledger_name"))
+                    .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
+                    .sessionClientBuilder(QldbSessionClient.builder())
+                    .build();
+            qldbTableName = config.getString("qldb_table_name");
+            if (!hasTableBeenCreated()) {
+                createTable();
+            }
+            for (IService service : services) {
+                if (!isServiceSetup(service)) {
+                    Collection<OperationModel> modelList = service.qldbSetup();
+                    insertIntoQLDB(new OperationModel(service.tableType(), Constants.DEFAULT_ITEM_KEY,
+                            null, null, null));
+                    for (OperationModel model : modelList) {
+                        insertIntoQLDB(model);
+                    }
                 }
             }
+            LOGGER.info("initialized qldb");
         }
-        LOGGER.info("initialized qldb");
+        catch(Exception e){
+            LOGGER.warn("failed to initialize qldb");
+        }
     }
 
     private static boolean hasTableBeenCreated() {

--- a/src/main/java/com/uid2/admin/audit/QLDBInit.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBInit.java
@@ -4,157 +4,50 @@ import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonSystemBuilder;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.uid2.admin.Constants;
-import com.uid2.admin.auth.AdminUser;
-import com.uid2.admin.auth.AdminUserProvider;
-import com.uid2.admin.model.Site;
-import com.uid2.admin.store.RotatingPartnerStore;
-import com.uid2.admin.store.RotatingSiteStore;
-import com.uid2.admin.vertx.JsonUtil;
 import com.uid2.admin.vertx.service.*;
-import com.uid2.shared.Const;
-import com.uid2.shared.Utils;
-import com.uid2.shared.auth.*;
-import com.uid2.shared.cloud.CloudUtils;
-import com.uid2.shared.cloud.ICloudStorage;
-import com.uid2.shared.model.EnclaveIdentifier;
-import com.uid2.shared.model.EncryptionKey;
-import com.uid2.shared.model.SaltEntry;
-import com.uid2.shared.store.RotatingKeyStore;
-import com.uid2.shared.store.RotatingSaltProvider;
-import com.uid2.shared.vertx.VertxUtils;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.apache.commons.codec.digest.DigestUtils;
 import software.amazon.awssdk.services.qldbsession.QldbSessionClient;
 import software.amazon.qldb.QldbDriver;
 import software.amazon.qldb.Result;
 import software.amazon.qldb.RetryPolicy;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class QLDBInit {
 
     private static final IonSystem ionSys = IonSystemBuilder.standard().build();
     private static QldbDriver qldbDriver;
-    private static JsonObject config;
-    private static String qldbLedgerName;
     private static String qldbTableName;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(QLDBInit.class);
-    private static final ObjectWriter jsonWriter = JsonUtil.createJsonWriter();
 
-    public static void main(String[] args) {
-        System.out.println("STARTING\n\n\n");
-        final String vertxConfigPath = System.getProperty(Const.Config.VERTX_CONFIG_PATH_PROP);
-        if (vertxConfigPath != null) {
-            System.out.format("Running CUSTOM CONFIG mode, config: %s\n", vertxConfigPath);
-        } else if (!Utils.isProductionEnvironment()) {
-            System.out.format("Running LOCAL DEBUG mode, config: %s\n", Const.Config.LOCAL_CONFIG_PATH);
-            System.setProperty(Const.Config.VERTX_CONFIG_PATH_PROP, Const.Config.LOCAL_CONFIG_PATH);
-        } else {
-            System.out.format("Running PRODUCTION mode, config: %s\n", Const.Config.OVERRIDE_CONFIG_PATH);
+    public static void init(List<IService> services, JsonObject config) {
+        qldbDriver = QldbDriver.builder()
+                .ledger(config.getString("qldb_ledger_name"))
+                .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
+                .sessionClientBuilder(QldbSessionClient.builder())
+                .build();
+        qldbTableName = config.getString("qldb_table_name");
+        if (!hasTableBeenCreated()) {
+            createTable();
         }
-        AtomicReference<JsonObject> atomicConfig = new AtomicReference<>();
-        Vertx vertx = Vertx.vertx();
-        VertxUtils.createConfigRetriever(vertx).getConfig(ar -> {
-            if (ar.failed()) {
-                LOGGER.fatal("Unable to read config: " + ar.cause().getMessage(), ar.cause());
-            }
-            atomicConfig.set(ar.result());
-
-            config = atomicConfig.get();
-            qldbLedgerName = config.getString("qldb_ledger_name");
-            qldbTableName = config.getString("qldb_table_name");
-            System.out.println("Ledger: " + qldbLedgerName + ", Table: " + qldbTableName);
-            qldbDriver = QldbDriver.builder()
-                    .ledger(qldbLedgerName)
-                    .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
-                    .sessionClientBuilder(QldbSessionClient.builder())
-                    .build();
-            try {
-                ICloudStorage cloudStorage = CloudUtils.createStorage(config.getString(Const.Config.CoreS3BucketProp), config);
-
-                Collection<Collection<OperationModel>> initModelLists = new HashSet<>();
-
-                String adminsMetadataPath = config.getString(AdminUserProvider.ADMINS_METADATA_PATH);
-                AdminUserProvider adminUserProvider = new AdminUserProvider(cloudStorage, adminsMetadataPath);
-                adminUserProvider.loadContent(adminUserProvider.getMetadata());
-                addAdminModels(initModelLists, adminUserProvider);
-
-                String sitesMetadataPath = config.getString(RotatingSiteStore.SITES_METADATA_PATH);
-                RotatingSiteStore siteProvider = new RotatingSiteStore(cloudStorage, sitesMetadataPath);
-                siteProvider.loadContent(siteProvider.getMetadata());
-                addSiteModels(initModelLists, siteProvider);
-
-                String clientMetadataPath = config.getString(Const.Config.ClientsMetadataPathProp);
-                RotatingClientKeyProvider clientKeyProvider = new RotatingClientKeyProvider(cloudStorage, clientMetadataPath);
-                clientKeyProvider.loadContent();
-                addClientModels(initModelLists, clientKeyProvider);
-
-                String keyMetadataPath = config.getString(Const.Config.KeysMetadataPathProp);
-                RotatingKeyStore keyProvider = new RotatingKeyStore(cloudStorage, keyMetadataPath);
-                keyProvider.loadContent();
-                addEncryptionKeyModels(initModelLists, keyProvider);
-
-                String keyAclMetadataPath = config.getString(Const.Config.KeysAclMetadataPathProp);
-                RotatingKeyAclProvider keyAclProvider = new RotatingKeyAclProvider(cloudStorage, keyAclMetadataPath);
-                keyAclProvider.loadContent();
-                addKeyAclModels(initModelLists, keyAclProvider);
-
-                String operatorMetadataPath = config.getString(Const.Config.OperatorsMetadataPathProp);
-                RotatingOperatorKeyProvider operatorKeyProvider = new RotatingOperatorKeyProvider(cloudStorage, cloudStorage, operatorMetadataPath);
-                operatorKeyProvider.loadContent(operatorKeyProvider.getMetadata());
-                addOperatorModels(initModelLists, operatorKeyProvider);
-
-                String enclaveMetadataPath = config.getString(EnclaveIdentifierProvider.ENCLAVES_METADATA_PATH);
-                EnclaveIdentifierProvider enclaveIdProvider = new EnclaveIdentifierProvider(cloudStorage, enclaveMetadataPath);
-                enclaveIdProvider.loadContent(enclaveIdProvider.getMetadata());
-                addEnclaveModels(initModelLists, enclaveIdProvider);
-
-                String saltMetadataPath = config.getString(Const.Config.SaltsMetadataPathProp);
-                RotatingSaltProvider saltProvider = new RotatingSaltProvider(cloudStorage, saltMetadataPath);
-                saltProvider.loadContent();
-                addSaltModels(initModelLists, saltProvider);
-
-                String partnerMetadataPath = config.getString(RotatingPartnerStore.PARTNERS_METADATA_PATH);
-                RotatingPartnerStore partnerConfigProvider = new RotatingPartnerStore(cloudStorage, partnerMetadataPath);
-                partnerConfigProvider.loadContent();
-                addPartnerModels(initModelLists, partnerConfigProvider);
-
-                if(!hasTableBeenCreated()){
-                    createTable();
+        for (IService service : services) {
+            if (!isServiceSetup(service)) {
+                Collection<OperationModel> modelList = service.qldbSetup();
+                insertIntoQLDB(new OperationModel(service.tableType(), Constants.DEFAULT_ITEM_KEY,
+                        null, null, null));
+                for (OperationModel model : modelList) {
+                    insertIntoQLDB(model);
                 }
-                if (!isTableSetup()) {
-                    for (Collection<OperationModel> modelList : initModelLists) {
-                        boolean createdAllItems = false;
-                        for(OperationModel model : modelList) {
-                            if (!createdAllItems) {
-                                createdAllItems = true;
-                                insertIntoQLDB(new OperationModel(model.itemType, Constants.DEFAULT_ITEM_KEY,
-                                        null, null, null));
-                            }
-                            insertIntoQLDB(model);
-                        }
-                    }
-                }
-                vertx.close();
-                System.exit(0);
-            } catch (Exception e) {
-                System.out.println("Failed to initialize QLDB");
-                vertx.close();
-                System.exit(-1);
             }
-        });
+        }
+        LOGGER.info("initialized qldb");
     }
 
-    private static boolean hasTableBeenCreated(){
-        try{
+    private static boolean hasTableBeenCreated() {
+        try {
             final IonStruct[] table = new IonStruct[1];
             qldbDriver.execute(txn -> {
                 Result result = txn.execute("SELECT * FROM information_schema.user_tables");
@@ -166,17 +59,17 @@ public class QLDBInit {
                 }
             });
             return table[0] != null;
-        }
-        catch(Exception e){
+        } catch (Exception e) {
             throw new RuntimeException("AWS configuration not set up");
         }
     }
 
-    private static boolean isTableSetup() {
+    private static boolean isServiceSetup(IService service) {
         try {
             final IonStruct[] count = new IonStruct[1];
             qldbDriver.execute(txn -> {
-                Result result = txn.execute("SELECT COUNT(*) AS \"count\" FROM " + qldbTableName);
+                Result result = txn.execute("SELECT COUNT(*) AS \"count\" FROM " + qldbTableName
+                        + " AS t WHERE t.data.itemType = ?", ionSys.newString(service.tableType().toString()));
                 count[0] = (IonStruct) result.iterator().next();
             });
             return !count[0].get("count").equals(ionSys.newInt(0));
@@ -204,147 +97,5 @@ public class QLDBInit {
             txn.execute("INSERT INTO " + qldbTableName + " VALUE ?",
                     ionSys.newLoader().load(jsonObject.toString()).get(0));
         });
-    }
-
-    private static void addAdminModels(Collection<Collection<OperationModel>> models, AdminUserProvider adminUserProvider) {
-        try {
-            Collection<AdminUser> adminUsers = adminUserProvider.getAll();
-            Collection<OperationModel> newModels = new HashSet<>();
-            for (AdminUser a : adminUsers) {
-                newModels.add(new OperationModel(Type.ADMIN, a.getName(), null,
-                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(a)), null));
-            }
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void addSiteModels(Collection<Collection<OperationModel>> models, RotatingSiteStore siteProvider) {
-        try {
-            Collection<Site> sites = siteProvider.getAllSites();
-            Collection<OperationModel> newModels = new HashSet<>();
-            for (Site s : sites) {
-                newModels.add(new OperationModel(Type.SITE, s.getName(), null,
-                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(s)), null));
-            }
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void addClientModels(Collection<Collection<OperationModel>> models, RotatingClientKeyProvider clientKeyProvider) {
-        try {
-            Collection<ClientKey> clients = clientKeyProvider.getAll();
-            Collection<OperationModel> newModels = new HashSet<>();
-            for (ClientKey c : clients) {
-                newModels.add(new OperationModel(Type.CLIENT, c.getName(), null,
-                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(c)), null));
-            }
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void addEncryptionKeyModels(Collection<Collection<OperationModel>> models, RotatingKeyStore keyProvider) {
-        try {
-            Collection<EncryptionKey> keys = keyProvider.getSnapshot().getActiveKeySet();
-            Collection<OperationModel> newModels = new HashSet<>();
-            for (EncryptionKey k : keys) {
-                newModels.add(new OperationModel(Type.KEY, String.valueOf(k.getId()), null,
-                        EncryptionKeyService.hashedToJsonWithKey(k), null));
-            }
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void addKeyAclModels(Collection<Collection<OperationModel>> models, RotatingKeyAclProvider keyAclProvider) {
-        try {
-            Map<Integer, EncryptionKeyAcl> mapAcl = keyAclProvider.getSnapshot().getAllAcls();
-            Collection<OperationModel> newModels = new HashSet<>();
-            for (int i : mapAcl.keySet()) {
-                JsonArray listedSites = new JsonArray();
-                EncryptionKeyAcl acl = mapAcl.get(i);
-                acl.getAccessList().stream().sorted().forEach(listedSites::add);
-                JsonObject jo = new JsonObject();
-                jo.put("site_id", i);
-                jo.put(acl.getIsWhitelist() ? "whitelist" : "blacklist", listedSites);
-
-                newModels.add(new OperationModel(Type.KEYACL, String.valueOf(i), null,
-                        DigestUtils.sha256Hex(jo.toString()), null));
-            }
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void addOperatorModels(Collection<Collection<OperationModel>> models, RotatingOperatorKeyProvider operatorKeyProvider) {
-        try {
-            Collection<OperatorKey> operatorCollection = operatorKeyProvider.getAll();
-            Collection<OperationModel> newModels = new HashSet<>();
-            for (OperatorKey o : operatorCollection) {
-                newModels.add(new OperationModel(Type.OPERATOR, o.getName(), null,
-                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(o)), null));
-            }
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void addEnclaveModels(Collection<Collection<OperationModel>> models, EnclaveIdentifierProvider enclaveIdProvider) {
-        try {
-            Collection<EnclaveIdentifier> enclaves = enclaveIdProvider.getAll();
-            Collection<OperationModel> newModels = new HashSet<>();
-            for (EnclaveIdentifier e : enclaves) {
-                newModels.add(new OperationModel(Type.ENCLAVE, e.getName(), null,
-                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(e)), null));
-            }
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void addSaltModels(Collection<Collection<OperationModel>> models, RotatingSaltProvider saltProvider) {
-        try {
-            List<RotatingSaltProvider.SaltSnapshot> snapshots = saltProvider.getSnapshots();
-            RotatingSaltProvider.SaltSnapshot lastSnapshot = snapshots.get(snapshots.size() - 1);
-
-            JsonObject jo = new JsonObject();
-            jo.put("effective", lastSnapshot.getEffective().toEpochMilli());
-            jo.put("expires", lastSnapshot.getExpires().toEpochMilli());
-            jo.put("salts_count", lastSnapshot.getAllRotatingSalts().length);
-            jo.put("min_last_updated", Arrays.stream(lastSnapshot.getAllRotatingSalts())
-                    .map(SaltEntry::getLastUpdated)
-                    .min(Long::compare).orElse(null));
-            jo.put("max_last_updated", Arrays.stream(lastSnapshot.getAllRotatingSalts())
-                    .map(SaltEntry::getLastUpdated)
-                    .max(Long::compare).orElse(null));
-
-            Collection<OperationModel> newModels = new HashSet<>();
-            newModels.add(new OperationModel(Type.SALT, "singleton", null,
-                    DigestUtils.sha256Hex(jo.toString()), null));
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void addPartnerModels(Collection<Collection<OperationModel>> models, RotatingPartnerStore partnerConfigProvider) {
-        try {
-            String config = partnerConfigProvider.getConfig();
-            Collection<OperationModel> newModels = new HashSet<>();
-            newModels.add(new OperationModel(Type.PARTNER, "singleton", null,
-                    DigestUtils.sha256Hex(config), null));
-            models.add(newModels);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 }

--- a/src/main/java/com/uid2/admin/audit/QLDBInit.java
+++ b/src/main/java/com/uid2/admin/audit/QLDBInit.java
@@ -5,50 +5,38 @@ import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.system.IonSystemBuilder;
 import com.uid2.admin.Constants;
-import com.uid2.admin.vertx.service.*;
+import com.uid2.admin.vertx.service.IService;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import software.amazon.awssdk.services.qldbsession.QldbSessionClient;
 import software.amazon.qldb.QldbDriver;
 import software.amazon.qldb.Result;
-import software.amazon.qldb.RetryPolicy;
 
-import java.util.*;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class QLDBInit {
+/**
+ * Handles creating a table, indices, and inserts documents passed to it. Note that all classes that extend
+ * QLDBInit should initialize qldbDriver and qldbTableName in their constructor.
+ */
+public abstract class QLDBInit implements IAuditInit{
 
-    private static final IonSystem ionSys = IonSystemBuilder.standard().build();
-    private static QldbDriver qldbDriver;
-    private static String qldbTableName;
-    private static final Logger LOGGER = LoggerFactory.getLogger(QLDBInit.class);
+    protected final IonSystem ionSys = IonSystemBuilder.standard().build();
+    protected QldbDriver qldbDriver;
+    protected String qldbTableName;
+    private final Logger LOGGER = LoggerFactory.getLogger(QLDBInit.class);
 
-    public static void init(List<IService> services, JsonObject config) {
+    @Override
+    public void init(Collection<OperationModel> modelList){
         try {
-            qldbDriver = QldbDriver.builder()
-                    .ledger(config.getString("qldb_ledger_name"))
-                    .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
-                    .sessionClientBuilder(QldbSessionClient.builder())
-                    .build();
-            qldbTableName = config.getString("qldb_table_name");
             if (!hasTableBeenCreated()) {
                 createTable();
             }
             if(!haveIndicesBeenCreated()){
                 createIndices();
             }
-            for (IService service : services) {
-                if (!isServiceSetup(service)) {
-                    Collection<OperationModel> modelList = service.qldbSetup();
-                    insertIntoQLDB(new OperationModel(service.tableType(), Constants.DEFAULT_ITEM_KEY,
-                            null, null, null));
-                    insertIntoQLDB(new OperationModel(service.tableType(), Constants.NULL_ITEM_KEY,
-                            null, null, null));
-                    for (OperationModel model : modelList) {
-                        insertIntoQLDB(model);
-                    }
-                }
+            for(OperationModel model : modelList){
+                insertIntoQLDB(model);
             }
             LOGGER.info("initialized qldb");
         }
@@ -57,7 +45,7 @@ public class QLDBInit {
         }
     }
 
-    private static boolean hasTableBeenCreated() {
+    protected boolean hasTableBeenCreated() {
         try {
             AtomicBoolean hasTableBeenCreated = new AtomicBoolean(false);
             qldbDriver.execute(txn -> {
@@ -71,7 +59,7 @@ public class QLDBInit {
         }
     }
 
-    private static boolean haveIndicesBeenCreated(){ //Assumes table exists
+    protected boolean haveIndicesBeenCreated(){ //Assumes table exists
         try {
             AtomicBoolean hasTableBeenCreated = new AtomicBoolean(false);
             qldbDriver.execute(txn -> {
@@ -86,21 +74,7 @@ public class QLDBInit {
         }
     }
 
-    private static boolean isServiceSetup(IService service) {
-        try {
-            final IonStruct[] count = new IonStruct[1];
-            qldbDriver.execute(txn -> {
-                Result result = txn.execute("SELECT COUNT(*) AS \"count\" FROM " + qldbTableName
-                        + " AS t WHERE t.data.itemType = ?", ionSys.newString(service.tableType().toString()));
-                count[0] = (IonStruct) result.iterator().next();
-            });
-            return !count[0].get("count").equals(ionSys.newInt(0));
-        } catch (Exception e) {
-            throw new RuntimeException("AWS configuration not set up");
-        }
-    }
-
-    private static void createTable() { //creates the logs table. Assumes it doesn't already exist
+    private void createTable() { //creates the logs table. Assumes it doesn't already exist
         try {
             qldbDriver.execute(txn -> {
                 txn.execute("CREATE TABLE " + qldbTableName);
@@ -110,7 +84,7 @@ public class QLDBInit {
         }
     }
 
-    private static void createIndices() { //creates indices on itemType and itemKey. Assumes they don't already exist.
+    private void createIndices() { //creates indices on itemType and itemKey. Assumes they don't already exist.
         try {
             qldbDriver.execute(txn -> {
                 txn.execute("CREATE INDEX ON " + qldbTableName + "(itemType)");
@@ -121,7 +95,7 @@ public class QLDBInit {
         }
     }
 
-    private static void insertIntoQLDB(OperationModel model) { //populates qldb
+    private void insertIntoQLDB(OperationModel model) { //populates qldb
         QLDBAuditModel auditModel = new QLDBAuditModel(model.itemType, model.itemKey, model.actionTaken, null,
                 null, null, -1, model.itemHash, model.summary);
         qldbDriver.execute(txn -> {

--- a/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
@@ -26,7 +26,10 @@ package com.uid2.admin.vertx.service;
 import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.uid2.admin.Constants;
-import com.uid2.admin.audit.*;
+import com.uid2.admin.audit.Actions;
+import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.OperationModel;
+import com.uid2.admin.audit.Type;
 import com.uid2.admin.auth.AdminUser;
 import com.uid2.admin.auth.AdminUserProvider;
 import com.uid2.admin.secret.IKeyGenerator;
@@ -392,11 +395,11 @@ public class AdminKeyService implements IService {
     }
 
     /**
-     * Writes an AdminUser to Json format, leaving out the sensitive key field.
+     * Writes an AdminUser to Json format, hashing the sensitive key field.
      * @param a the AdminUser to write
-     * @return a JsonObject representing a, without the key field.
+     * @return a JsonObject representing a, without a hashed key field.
      */
-    public JsonObject adminToJson(AdminUser a){ // should hash key
+    public JsonObject adminToJson(AdminUser a){
         JsonObject jo = new JsonObject();
 
         jo.put("name", a.getName());
@@ -404,6 +407,7 @@ public class AdminKeyService implements IService {
         jo.put("roles", RequestUtil.getRolesSpec(a.getRoles()));
         jo.put("created", a.getCreated());
         jo.put("disabled", a.isDisabled());
+        jo.put("key", DigestUtils.sha256Hex(a.getKey()));
 
         return jo;
     }

--- a/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
@@ -407,7 +407,7 @@ public class AdminKeyService implements IService {
         jo.put("roles", RequestUtil.getRolesSpec(a.getRoles()));
         jo.put("created", a.getCreated());
         jo.put("disabled", a.isDisabled());
-        jo.put("key", DigestUtils.sha256Hex(a.getKey()));
+        jo.put("key", DigestUtils.sha256Hex(a.getKey() == null ? "" : a.getKey()));
 
         return jo;
     }

--- a/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
@@ -124,12 +124,34 @@ public class AdminKeyService implements IService {
         }), Role.ADMINISTRATOR));
     }
 
+    @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            Collection<AdminUser> adminUsers = adminUserProvider.getAll();
+            Collection<OperationModel> newModels = new HashSet<>();
+            for (AdminUser a : adminUsers) {
+                newModels.add(new OperationModel(Type.ADMIN, a.getName(), null,
+                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(a)), null));
+            }
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.ADMIN;
+    }
+
     private void handleAdminMetadata(RoutingContext rc) {
         try {
             rc.response()
                     .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                     .end(adminUserProvider.getMetadata().encode());
         } catch (Exception e) {
+            e.printStackTrace();
             rc.fail(500, e);
         }
     }
@@ -374,7 +396,7 @@ public class AdminKeyService implements IService {
      * @param a the AdminUser to write
      * @return a JsonObject representing a, without the key field.
      */
-    public JsonObject adminToJson(AdminUser a){
+    public JsonObject adminToJson(AdminUser a){ // should hash key
         JsonObject jo = new JsonObject();
 
         jo.put("name", a.getName());

--- a/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
@@ -130,7 +130,6 @@ public class AdminKeyService implements IService {
                     .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                     .end(adminUserProvider.getMetadata().encode());
         } catch (Exception e) {
-            e.printStackTrace();
             rc.fail(500, e);
         }
     }
@@ -153,7 +152,7 @@ public class AdminKeyService implements IService {
             return null;
         }
     }
-    // consider constructing AuditModel here and return it, therefore AuditModel can access additional context
+
     private List<OperationModel> handleAdminReveal(RoutingContext rc) {
         try {
             AdminUser a = getAdminUser(rc.queryParam("name"));

--- a/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
@@ -27,7 +27,7 @@ import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.uid2.admin.Constants;
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
 import com.uid2.admin.auth.AdminUser;
@@ -53,7 +53,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class AdminKeyService implements IService {
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
@@ -63,7 +63,7 @@ public class AdminKeyService implements IService {
     private final String adminKeyPrefix;
 
     public AdminKeyService(JsonObject config,
-                           AuditMiddleware audit,
+                           IAuditMiddleware audit,
                            AuthMiddleware auth,
                            WriteLock writeLock,
                            IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/AdminKeyService.java
@@ -346,7 +346,7 @@ public class AdminKeyService implements IService {
             // return admin with new key
             rc.response().end(jsonWriter.writeValueAsString(a));
             return Collections.singletonList(new OperationModel(Type.ADMIN, a.getName(), Actions.UPDATE,
-                    DigestUtils.sha256Hex(adminToJson(a).toString()), "rekeyed " + a.getName()));
+                    DigestUtils.sha256Hex(jsonWriter.writeValueAsString(a)), "rekeyed " + a.getName()));
         } catch (Exception e) {
             rc.fail(500, e);
             return null;
@@ -386,7 +386,7 @@ public class AdminKeyService implements IService {
                 stringRoleList.add(role.toString());
             }
             return Collections.singletonList(new OperationModel(Type.ADMIN, a.getName(), Actions.UPDATE,
-                    DigestUtils.sha256Hex(adminToJson(a).toString()), "set roles of " + a.getName() +
+                    DigestUtils.sha256Hex(jsonWriter.writeValueAsString(a)), "set roles of " + a.getName() +
                     " to {" + StringUtils.join(",", stringRoleList.toArray(new String[0])) + "}"));
         } catch (Exception e) {
             rc.fail(500, e);
@@ -395,7 +395,7 @@ public class AdminKeyService implements IService {
     }
 
     /**
-     * Writes an AdminUser to Json format, hashing the sensitive key field.
+     * Writes an AdminUser to Json format, without the sensitive key field.
      * @param a the AdminUser to write
      * @return a JsonObject representing a, without a hashed key field.
      */
@@ -407,7 +407,6 @@ public class AdminKeyService implements IService {
         jo.put("roles", RequestUtil.getRolesSpec(a.getRoles()));
         jo.put("created", a.getCreated());
         jo.put("disabled", a.isDisabled());
-        jo.put("key", DigestUtils.sha256Hex(a.getKey() == null ? "" : a.getKey()));
 
         return jo;
     }

--- a/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
@@ -27,10 +27,9 @@ import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.uid2.admin.Constants;
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
-import com.uid2.admin.auth.AdminUser;
 import com.uid2.admin.secret.IKeyGenerator;
 import com.uid2.admin.model.Site;
 import com.uid2.admin.store.ISiteStore;
@@ -56,7 +55,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class ClientKeyService implements IService {
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
@@ -67,7 +66,7 @@ public class ClientKeyService implements IService {
     private final String clientKeyPrefix;
 
     public ClientKeyService(JsonObject config,
-                            AuditMiddleware audit,
+                            IAuditMiddleware audit,
                             AuthMiddleware auth,
                             WriteLock writeLock,
                             IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
@@ -136,6 +136,27 @@ public class ClientKeyService implements IService {
         }), Role.CLIENTKEY_ISSUER));
     }
 
+    @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            Collection<ClientKey> clients = clientKeyProvider.getAll();
+            Collection<OperationModel> newModels = new HashSet<>();
+            for (ClientKey c : clients) {
+                newModels.add(new OperationModel(Type.CLIENT, c.getName(), null,
+                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(c)), null));
+            }
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.CLIENT;
+    }
+
     private void handleClientMetadata(RoutingContext rc) {
         try {
             rc.response()

--- a/src/main/java/com/uid2/admin/vertx/service/EnclaveIdService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/EnclaveIdService.java
@@ -26,7 +26,7 @@ package com.uid2.admin.vertx.service;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.uid2.admin.Constants;
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
 import com.uid2.admin.store.IStorageManager;
@@ -51,14 +51,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class EnclaveIdService implements IService {
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
     private final EnclaveIdentifierProvider enclaveIdProvider;
     private final ObjectWriter jsonWriter = JsonUtil.createJsonWriter();
 
-    public EnclaveIdService(AuditMiddleware audit,
+    public EnclaveIdService(IAuditMiddleware audit,
                             AuthMiddleware auth,
                             WriteLock writeLock,
                             IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/EnclaveIdService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/EnclaveIdService.java
@@ -88,6 +88,27 @@ public class EnclaveIdService implements IService {
         }), Role.ADMINISTRATOR));
     }
 
+    @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            Collection<EnclaveIdentifier> enclaves = enclaveIdProvider.getAll();
+            Collection<OperationModel> newModels = new HashSet<>();
+            for (EnclaveIdentifier e : enclaves) {
+                newModels.add(new OperationModel(Type.ENCLAVE, e.getName(), null,
+                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(e)), null));
+            }
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.ENCLAVE;
+    }
+
     private void handleEnclaveMetadata(RoutingContext rc) {
         try {
             rc.response()

--- a/src/main/java/com/uid2/admin/vertx/service/EncryptionKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/EncryptionKeyService.java
@@ -127,6 +127,27 @@ public class EncryptionKeyService implements IService, IEncryptionKeyManager {
     }
 
     @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            Collection<EncryptionKey> keys = keyProvider.getSnapshot().getActiveKeySet();
+            Collection<OperationModel> newModels = new HashSet<>();
+            for (EncryptionKey k : keys) {
+                newModels.add(new OperationModel(Type.KEY, String.valueOf(k.getId()), null,
+                        EncryptionKeyService.hashedToJsonWithKey(k), null));
+            }
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.KEY;
+    }
+
+    @Override
     public EncryptionKey addSiteKey(int siteId) throws Exception {
         // force refresh manually
         this.keyProvider.loadContent();

--- a/src/main/java/com/uid2/admin/vertx/service/EncryptionKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/EncryptionKeyService.java
@@ -26,7 +26,7 @@ package com.uid2.admin.vertx.service;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.uid2.admin.Constants;
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
 import com.uid2.admin.secret.IEncryptionKeyManager;
@@ -68,7 +68,7 @@ public class EncryptionKeyService implements IService, IEncryptionKeyManager {
     private static final String SITE_KEY_EXPIRES_AFTER_SECONDS = "site_key_expires_after_seconds";
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionKeyService.class);
 
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
@@ -83,7 +83,7 @@ public class EncryptionKeyService implements IService, IEncryptionKeyManager {
     private List<EncryptionKey> allKeys;
 
     public EncryptionKeyService(JsonObject config,
-                                AuditMiddleware audit,
+                                IAuditMiddleware audit,
                                 AuthMiddleware auth,
                                 WriteLock writeLock,
                                 IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/IService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/IService.java
@@ -24,11 +24,13 @@
 package com.uid2.admin.vertx.service;
 
 import com.uid2.admin.audit.OperationModel;
+import com.uid2.admin.audit.Type;
 import io.vertx.ext.web.Router;
 
 import java.util.Collection;
 
 public interface IService {
     void setupRoutes(Router router);
-
+    Collection<OperationModel> qldbSetup();
+    Type tableType();
 }

--- a/src/main/java/com/uid2/admin/vertx/service/KeyAclService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/KeyAclService.java
@@ -92,6 +92,28 @@ public class KeyAclService implements IService {
         }), Role.CLIENTKEY_ISSUER));
     }
 
+    @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            Map<Integer, EncryptionKeyAcl> mapAcl = keyAclProvider.getSnapshot().getAllAcls();
+            Collection<OperationModel> newModels = new HashSet<>();
+            for (int i : mapAcl.keySet()) {
+                JsonObject jo = toJson(i, mapAcl.get(i));
+                newModels.add(new OperationModel(Type.KEYACL, String.valueOf(i), null,
+                        DigestUtils.sha256Hex(jo.toString()), null));
+            }
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.KEYACL;
+    }
+
     private List<OperationModel> handleKeyAclList(RoutingContext rc) {
         try {
             JsonArray ja = new JsonArray();

--- a/src/main/java/com/uid2/admin/vertx/service/KeyAclService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/KeyAclService.java
@@ -25,7 +25,7 @@ package com.uid2.admin.vertx.service;
 
 import com.uid2.admin.Constants;
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
 import com.uid2.admin.secret.IEncryptionKeyManager;
@@ -51,7 +51,7 @@ import java.util.*;
 import java.util.function.Function;
 
 public class KeyAclService implements IService {
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
@@ -59,7 +59,7 @@ public class KeyAclService implements IService {
     private final ISiteStore siteProvider;
     private final IEncryptionKeyManager keyManager;
 
-    public KeyAclService(AuditMiddleware audit,
+    public KeyAclService(IAuditMiddleware audit,
                          AuthMiddleware auth,
                          WriteLock writeLock,
                          IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/OperatorKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/OperatorKeyService.java
@@ -117,6 +117,27 @@ public class OperatorKeyService implements IService {
         }), Role.ADMINISTRATOR));
     }
 
+    @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            Collection<OperatorKey> operatorCollection = operatorKeyProvider.getAll();
+            Collection<OperationModel> newModels = new HashSet<>();
+            for (OperatorKey o : operatorCollection) {
+                newModels.add(new OperationModel(Type.OPERATOR, o.getName(), null,
+                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(o)), null));
+            }
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.OPERATOR;
+    }
+
     private void handleOperatorMetadata(RoutingContext rc) {
         try {
             rc.response()

--- a/src/main/java/com/uid2/admin/vertx/service/OperatorKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/OperatorKeyService.java
@@ -26,7 +26,7 @@ package com.uid2.admin.vertx.service;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.uid2.admin.Constants;
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
 import com.uid2.admin.secret.IKeyGenerator;
@@ -52,7 +52,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class OperatorKeyService implements IService {
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
@@ -62,7 +62,7 @@ public class OperatorKeyService implements IService {
     private final String operatorKeyPrefix;
 
     public OperatorKeyService(JsonObject config,
-                              AuditMiddleware audit,
+                              IAuditMiddleware audit,
                               AuthMiddleware auth,
                               WriteLock writeLock,
                               IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/PartnerConfigService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/PartnerConfigService.java
@@ -71,6 +71,25 @@ public class PartnerConfigService implements IService {
         }), Role.ADMINISTRATOR));
     }
 
+    @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            String config = partnerConfigProvider.getConfig();
+            Collection<OperationModel> newModels = new HashSet<>();
+            newModels.add(new OperationModel(Type.PARTNER, "singleton", null,
+                    DigestUtils.sha256Hex(config), null));
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.PARTNER;
+    }
+
     private List<OperationModel> handlePartnerConfigGet(RoutingContext rc) {
         try {
             String config = this.partnerConfigProvider.getConfig();

--- a/src/main/java/com/uid2/admin/vertx/service/PartnerConfigService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/PartnerConfigService.java
@@ -24,7 +24,7 @@
 package com.uid2.admin.vertx.service;
 
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
 import com.uid2.admin.store.IStorageManager;
@@ -43,13 +43,13 @@ import java.util.*;
 import java.util.function.Function;
 
 public class PartnerConfigService implements IService {
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
     private final RotatingPartnerStore partnerConfigProvider;
 
-    public PartnerConfigService(AuditMiddleware audit,
+    public PartnerConfigService(IAuditMiddleware audit,
                                 AuthMiddleware auth,
                                 WriteLock writeLock,
                                 IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/SaltService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/SaltService.java
@@ -81,6 +81,29 @@ public class SaltService implements IService {
         }), Role.SECRET_MANAGER));
     }
 
+    @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            List<RotatingSaltProvider.SaltSnapshot> snapshots = saltProvider.getSnapshots();
+            RotatingSaltProvider.SaltSnapshot lastSnapshot = snapshots.get(snapshots.size() - 1);
+
+            JsonObject jo = toJson(lastSnapshot);
+
+            Collection<OperationModel> newModels = new HashSet<>();
+            newModels.add(new OperationModel(Type.SALT, "singleton", null,
+                    DigestUtils.sha256Hex(jo.toString()), null));
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.SALT;
+    }
+
     private List<OperationModel> handleSaltSnapshots(RoutingContext rc) {
         try {
             final JsonArray ja = new JsonArray();

--- a/src/main/java/com/uid2/admin/vertx/service/SaltService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/SaltService.java
@@ -24,7 +24,7 @@
 package com.uid2.admin.vertx.service;
 
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
 import com.uid2.admin.secret.ISaltRotation;
@@ -49,14 +49,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class SaltService implements IService {
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
     private final RotatingSaltProvider saltProvider;
     private final ISaltRotation saltRotation;
 
-    public SaltService(AuditMiddleware audit,
+    public SaltService(IAuditMiddleware audit,
                        AuthMiddleware auth,
                        WriteLock writeLock,
                        IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/SiteService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/SiteService.java
@@ -26,7 +26,7 @@ package com.uid2.admin.vertx.service;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.uid2.admin.Constants;
 import com.uid2.admin.audit.Actions;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.OperationModel;
 import com.uid2.admin.audit.Type;
 import com.uid2.admin.model.Site;
@@ -53,7 +53,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class SiteService implements IService {
-    private final AuditMiddleware audit;
+    private final IAuditMiddleware audit;
     private final AuthMiddleware auth;
     private final WriteLock writeLock;
     private final IStorageManager storageManager;
@@ -61,7 +61,7 @@ public class SiteService implements IService {
     private final IClientKeyProvider clientKeyProvider;
     private final ObjectWriter jsonWriter = JsonUtil.createJsonWriter();
 
-    public SiteService(AuditMiddleware audit,
+    public SiteService(IAuditMiddleware audit,
                        AuthMiddleware auth,
                        WriteLock writeLock,
                        IStorageManager storageManager,

--- a/src/main/java/com/uid2/admin/vertx/service/SiteService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/SiteService.java
@@ -90,6 +90,27 @@ public class SiteService implements IService {
         }), Role.CLIENTKEY_ISSUER));
     }
 
+    @Override
+    public Collection<OperationModel> qldbSetup(){
+        try {
+            Collection<Site> sites = siteProvider.getAllSites();
+            Collection<OperationModel> newModels = new HashSet<>();
+            for (Site s : sites) {
+                newModels.add(new OperationModel(Type.SITE, s.getName(), null,
+                        DigestUtils.sha256Hex(jsonWriter.writeValueAsString(s)), null));
+            }
+            return newModels;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Type tableType(){
+        return Type.SITE;
+    }
+
     private List<OperationModel> handleSiteList(RoutingContext rc) {
         try {
             JsonArray ja = new JsonArray();

--- a/src/test/java/com/uid2/admin/vertx/AdminLogTest.java
+++ b/src/test/java/com/uid2/admin/vertx/AdminLogTest.java
@@ -105,8 +105,6 @@ public class AdminLogTest extends ServiceTestBase {
                     .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
                     .sessionClientBuilder(QldbSessionClient.builder())
                     .build();
-            AdminQLDBInit init = new AdminQLDBInit(config);
-            init.init(Collections.singletonList(adminKeyService));
         }
         else{
             setAdminLoad(1);

--- a/src/test/java/com/uid2/admin/vertx/AdminLogTest.java
+++ b/src/test/java/com/uid2/admin/vertx/AdminLogTest.java
@@ -53,7 +53,7 @@ public class AdminLogTest extends ServiceTestBase {
     private final String fakeAdmin = "some-fake-admin";
 
     @Captor
-    private ArgumentCaptor<Collection<AuditModel>> auditModelCaptor;
+    private ArgumentCaptor<Collection<IAuditModel>> auditModelCaptor;
 
     @Override
     protected IService createService() {
@@ -105,7 +105,8 @@ public class AdminLogTest extends ServiceTestBase {
                     .transactionRetryPolicy(RetryPolicy.builder().maxRetries(3).build())
                     .sessionClientBuilder(QldbSessionClient.builder())
                     .build();
-            QLDBInit.init(Collections.singletonList(adminKeyService), config);
+            AdminQLDBInit init = new AdminQLDBInit(config);
+            init.init(Collections.singletonList(adminKeyService));
         }
         else{
             setAdminLoad(1);
@@ -386,8 +387,8 @@ public class AdminLogTest extends ServiceTestBase {
             this.summary = summary;
         }
 
-        public boolean matches(Collection<AuditModel> modelList){
-            AuditModel model = modelList.iterator().next();
+        public boolean matches(Collection<IAuditModel> modelList){
+            IAuditModel model = modelList.iterator().next();
             if(!(model instanceof QLDBAuditModel)) return false;
             QLDBAuditModel qldbModel = (QLDBAuditModel) model;
             if(itemType != null && !itemType.equals(qldbModel.itemType)) return false;

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -24,9 +24,9 @@
 package com.uid2.admin.vertx.test;
 
 import com.uid2.admin.audit.AuditFactory;
-import com.uid2.admin.audit.AuditMiddleware;
+import com.uid2.admin.audit.IAuditMiddleware;
 import com.uid2.admin.audit.AuditMiddlewareImpl;
-import com.uid2.admin.audit.AuditWriter;
+import com.uid2.admin.audit.IAuditWriter;
 import com.uid2.admin.auth.AdminUser;
 import com.uid2.admin.auth.AdminUserProvider;
 import com.uid2.admin.auth.IAuthHandlerFactory;
@@ -77,8 +77,8 @@ public abstract class ServiceTestBase {
     protected final JsonObject config = new JsonObject();
     protected final WriteLock writeLock = new WriteLock();
     protected AuthMiddleware auth;
-    protected AuditMiddleware audit;
-    @Mock protected AuditWriter mockedAuditWriter;
+    protected IAuditMiddleware audit;
+    @Mock protected IAuditWriter mockedAuditWriter;
     @Mock protected AuthHandler authHandler;
     @Mock protected IAuthHandlerFactory authHandlerFactory;
     @Mock protected IStorageManager storageManager;

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public abstract class ServiceTestBase {
-    public final static boolean qldbConnection = true; // if computer has QLDB credentials, this variable can be true, otherwise leave false
+    public final static boolean qldbConnection = false; // if computer has QLDB credentials, this variable can be true, otherwise leave false
     protected AutoCloseable mocks;
     protected final JsonObject config = new JsonObject();
     protected final WriteLock writeLock = new WriteLock();

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public abstract class ServiceTestBase {
-    public final static boolean qldbConnection = false; // if computer has QLDB credentials, this variable can be true, otherwise leave false
+    public final static boolean qldbConnection = true; // if computer has QLDB credentials, this variable can be true, otherwise leave false
     protected AutoCloseable mocks;
     protected final JsonObject config = new JsonObject();
     protected final WriteLock writeLock = new WriteLock();

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -96,8 +96,8 @@ public abstract class ServiceTestBase {
 
     @BeforeEach
     public void deployVerticle(Vertx vertx, VertxTestContext testContext) throws Throwable {
-        config.put("qldb_ledger_name", "audit-logs");
-        config.put("qldb_table_name", "logs");
+        config.put("qldb_ledger_name", "uid2-audit-logs");
+        config.put("qldb_table_name", "admin_logs");
         config.put("enable_qldb_admin_logging", qldbConnection);
         mocks = MockitoAnnotations.openMocks(this);
         when(authHandlerFactory.createAuthHandler(any(), any())).thenReturn(authHandler);


### PR DESCRIPTION
Implemented log-before-write. If writing to the QLDB fails, the endpoint returns a 500 error and does not apply any changes requested from the user, if applicable. Most of the changes in the services are procedural ones, but EncryptionKeyService.java required a fair amount of reorganizing to implement. No test cases were changed, so the end behavior should still be the same assuming writing to QLDB is successful.

Implemented itemType and itemKey as top-level fields for the purposes of indexing on the QLDB. Also implemented indexing on the QLDB, which is necessary to keep infra costs manageable at large database sizes.

Added a new QLDB entry for the null item. This entry is written to in the case where a client writes (correctly) to an endpoint expecting possibly multiple items in the S3 to be modified, but no item is actually modified. Currently, only a single service (EncryptionKeyService.java) writes to the item in the QLDB.