### PR TITLE
Ensure Enclave ID Generation does not use Operator API Key

### DIFF
--- a/webroot/adm/enclave-gcp.html
+++ b/webroot/adm/enclave-gcp.html
@@ -222,8 +222,8 @@ write_files:
         }
 
         cloudInit = cloudInit
-          .replace(/^([ \t]*Environment=.UID2_ENCLAVE_API_TOKEN)=.+?\"$/gm, '$1=' + apiToken + '"')
-          .replace(/^([ \t]*Environment=.UID2_ENCLAVE_IMAGE_ID)=.+?\"$/gm, '$1=' + imageId + '"');
+          .replace(/^([ \t]*Environment=.UID2_ENCLAVE_API_TOKEN)=.*?\"$/gm, '$1=' + apiToken + '"')
+          .replace(/^([ \t]*Environment=.UID2_ENCLAVE_IMAGE_ID)=.*?\"$/gm, '$1=' + imageId + '"');
 
         download(fn, cloudInit);
 
@@ -247,7 +247,7 @@ write_files:
 
         enclaveParamsList.forEach(p => {
           var enclaveParam = "UID2_ENCLAVE_" + p;
-          const reMaskParam = new RegExp('^([ \t]*Environment=.' + enclaveParam + ')=.+?\"$', 'gm');
+          const reMaskParam = new RegExp('^([ \t]*Environment=.' + enclaveParam + ')=.*?\"$', 'gm');
           tplCloudInit = tplCloudInit.replace(reMaskParam, '$1=dummy"');
         });
 

--- a/webroot/adm/enclave-gcp.html
+++ b/webroot/adm/enclave-gcp.html
@@ -241,7 +241,7 @@ write_files:
         var tplCloudInit = cloudInit;
         var enclaveParams = "API_TOKEN,IMAGE_ID";
         if (env == 'prod') {
-          enclaveParams = "API_TOKEN,";
+          enclaveParams = "API_TOKEN";
         }
         var enclaveParamsList = enclaveParams.split(',');
 


### PR DESCRIPTION
Fixed bug where an empty Operator API Key (or Docker Image ID in Integration) would result in a different enclave ID. The enclave ID should remain consistent, regardless of the value of the Operator API Key