### PR TITLE
Syw UId2-1534 reserve right keyset id for special encryption keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.1.0</micrometer.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <uid2-shared.version>3.1.0-691c76475f</uid2-shared.version>
+        <uid2-shared.version>3.1.3-SNAPSHOT</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
       <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.1.0</micrometer.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <uid2-shared.version>2.10.0-726a7a3447</uid2-shared.version>
+        <uid2-shared.version>3.1.0-691c76475f</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
       <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.1.0</micrometer.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <uid2-shared.version>3.1.3-SNAPSHOT</uid2-shared.version>
+        <uid2-shared.version>3.1.0-691c76475f</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
       <repositories>

--- a/src/main/java/com/uid2/admin/util/KeysetUtil.java
+++ b/src/main/java/com/uid2/admin/util/KeysetUtil.java
@@ -3,9 +3,12 @@ package com.uid2.admin.util;
 import com.uid2.shared.auth.Keyset;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static java.lang.Math.max;
 
 public class KeysetUtil {
     public static Keyset lookUpKeyset(int siteId, Map<Integer, Keyset> keysets) {
@@ -18,7 +21,8 @@ public class KeysetUtil {
     }
 
     public static Integer getMaxKeyset(Map<Integer, Keyset> keysets) {
-        return keysets.keySet().size();
+        if(keysets.isEmpty()) return 3;
+        return max(Collections.max(keysets.keySet()), 3);
     }
 
     public static Keyset createDefaultKeyset(int siteId, int keysetId) {

--- a/src/main/java/com/uid2/admin/util/KeysetUtil.java
+++ b/src/main/java/com/uid2/admin/util/KeysetUtil.java
@@ -21,6 +21,8 @@ public class KeysetUtil {
     }
 
     public static Integer getMaxKeyset(Map<Integer, Keyset> keysets) {
+        // keyset id 1/2/3 are assigned for master/refresh/default publisher encryption key ids,
+        // so we always reserve these 3 keyset ids for them
         if(keysets.isEmpty()) return 3;
         return max(Collections.max(keysets.keySet()), 3);
     }

--- a/src/main/java/com/uid2/admin/util/KeysetUtil.java
+++ b/src/main/java/com/uid2/admin/util/KeysetUtil.java
@@ -12,6 +12,12 @@ import java.util.stream.Collectors;
 import static java.lang.Math.max;
 
 public class KeysetUtil {
+
+    public static final String MasterKeysetName = "Master";
+    public static final String RefreshKeysetName = "Refresh";
+    public static final String FallbackPublisherKeysetName = "Fallback Publisher";
+
+
     public static Keyset lookUpKeyset(int siteId, Map<Integer, Keyset> keysets) {
         for (Keyset keyset: keysets.values()) {
             if(keyset.getSiteId() == siteId && keyset.isDefault()) {
@@ -34,13 +40,13 @@ public class KeysetUtil {
         //only set if both siteId and keysetId match our expectation according to the requirements
         //or otherwise we know there's a bug in other codes
         if(siteId == Const.Data.MasterKeySiteId && keysetId == Const.Data.MasterKeysetId) {
-            name = Const.Data.MasterKeysetName;
+            name = MasterKeysetName;
         }
         else if(siteId == Const.Data.RefreshKeySiteId && keysetId == Const.Data.RefreshKeysetId) {
-            name = Const.Data.RefreshKeysetName;
+            name = RefreshKeysetName;
         }
         else if(siteId == Const.Data.AdvertisingTokenSiteId && keysetId == Const.Data.FallbackPublisherKeysetId) {
-            name = Const.Data.FallbackPublisherKeysetName;
+            name = FallbackPublisherKeysetName;
         }
         return new Keyset(keysetId, siteId, name, null, Instant.now().getEpochSecond(), true, true);
     }

--- a/src/main/java/com/uid2/admin/util/KeysetUtil.java
+++ b/src/main/java/com/uid2/admin/util/KeysetUtil.java
@@ -1,5 +1,6 @@
 package com.uid2.admin.util;
 
+import com.uid2.shared.Const;
 import com.uid2.shared.auth.Keyset;
 
 import java.time.Instant;
@@ -28,6 +29,19 @@ public class KeysetUtil {
     }
 
     public static Keyset createDefaultKeyset(int siteId, int keysetId) {
-        return new Keyset(keysetId, siteId, "", null, Instant.now().getEpochSecond(), true, true);
+        String name = "";
+
+        //only set if both siteId and keysetId match our expectation according to the requirements
+        //or otherwise we know there's a bug in other codes
+        if(siteId == Const.Data.MasterKeySiteId && keysetId == Const.Data.MasterKeysetId) {
+            name = Const.Data.MasterKeysetName;
+        }
+        else if(siteId == Const.Data.RefreshKeySiteId && keysetId == Const.Data.RefreshKeysetId) {
+            name = Const.Data.RefreshKeysetName;
+        }
+        else if(siteId == Const.Data.AdvertisingTokenSiteId && keysetId == Const.Data.FallbackPublisherKeysetId) {
+            name = Const.Data.FallbackPublisherKeysetName;
+        }
+        return new Keyset(keysetId, siteId, name, null, Instant.now().getEpochSecond(), true, true);
     }
 }

--- a/src/main/java/com/uid2/admin/vertx/service/EncryptionKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/EncryptionKeyService.java
@@ -548,6 +548,15 @@ public class EncryptionKeyService implements IService, IEncryptionKeyManager, IK
         Keyset keyset = lookUpKeyset(siteId, currentKeysets);
         if(keyset == null) {
             int newKeysetId = getMaxKeyset(currentKeysets)+1;
+            if(siteId == Const.Data.MasterKeySiteId) {
+                newKeysetId = Const.Data.MasterKeysetId;
+            }
+            if(siteId == Const.Data.RefreshKeySiteId) {
+                newKeysetId = Const.Data.RefreshKeysetId;
+            }
+            if(siteId == Const.Data.AdvertisingTokenSiteId) {
+                newKeysetId = Const.Data.FallbackPublisherKeysetId;
+            }
             keyset = createDefaultKeyset(siteId, newKeysetId);
             currentKeysets.put(newKeysetId, keyset);
             keysetStoreWriter.upload(currentKeysets, null);

--- a/src/main/java/com/uid2/admin/vertx/service/EncryptionKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/EncryptionKeyService.java
@@ -551,10 +551,10 @@ public class EncryptionKeyService implements IService, IEncryptionKeyManager, IK
             if(siteId == Const.Data.MasterKeySiteId) {
                 newKeysetId = Const.Data.MasterKeysetId;
             }
-            if(siteId == Const.Data.RefreshKeySiteId) {
+            else if(siteId == Const.Data.RefreshKeySiteId) {
                 newKeysetId = Const.Data.RefreshKeysetId;
             }
-            if(siteId == Const.Data.AdvertisingTokenSiteId) {
+            else if(siteId == Const.Data.AdvertisingTokenSiteId) {
                 newKeysetId = Const.Data.FallbackPublisherKeysetId;
             }
             keyset = createDefaultKeyset(siteId, newKeysetId);

--- a/src/main/java/com/uid2/admin/vertx/service/SharingService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/SharingService.java
@@ -43,13 +43,13 @@ public class SharingService implements IService {
     @Override
     public void setupRoutes(Router router) {
         router.get("/api/sharing/lists").handler(
-                auth.handle(this::handleListAllAllowlist, Role.SHARING_PORTAL)
+                auth.handle(this::handleListAllAllowedSites, Role.SHARING_PORTAL)
         );
         router.get("/api/sharing/list/:siteId").handler(
-                auth.handle(this::handleListAllowlist, Role.SHARING_PORTAL)
+                auth.handle(this::handleListAllowedSites, Role.SHARING_PORTAL)
         );
         router.post("/api/sharing/list/:siteId").handler(
-                auth.handle(this::handleSetAllowlist, Role.SHARING_PORTAL)
+                auth.handle(this::handleSetAllowedSites, Role.SHARING_PORTAL)
         );
 
         router.get("/api/sharing/keysets").handler(
@@ -74,7 +74,7 @@ public class SharingService implements IService {
 
             final JsonObject body = rc.body().asJsonObject();
 
-           final JsonArray whitelist = body.getJsonArray("allowlist");
+           final JsonArray whitelist = body.getJsonArray("allowed_sites");
            Integer keysetId = body.getInteger("keyset_id");
            final Integer siteId = body.getInteger("site_id");
 
@@ -120,7 +120,7 @@ public class SharingService implements IService {
         jo.put("keyset_id", keyset.getKeysetId());
         jo.put("site_id", keyset.getSiteId());
         jo.put("name", keyset.getName());
-        jo.put("allowlist", keyset.getAllowedSites());
+        jo.put("allowed_sites", keyset.getAllowedSites());
         jo.put("created", keyset.getCreated());
         jo.put("is_enabled", keyset.isEnabled());
         jo.put("is_default", keyset.isDefault());
@@ -177,7 +177,7 @@ public class SharingService implements IService {
         }
     }
 
-    private void handleListAllowlist(RoutingContext rc) {
+    private void handleListAllowedSites(RoutingContext rc) {
         int siteId;
         try {
             siteId = Integer.parseInt(rc.pathParam("siteId"));
@@ -201,7 +201,7 @@ public class SharingService implements IService {
             allowedSites.stream().sorted().forEach((listedSiteId) -> listedSites.add(listedSiteId));
         }
         JsonObject jo = new JsonObject();
-        jo.put("allowlist", listedSites);
+        jo.put("allowed_sites", listedSites);
         jo.put("hash", keyset.hashCode());
 
         rc.response()
@@ -209,7 +209,7 @@ public class SharingService implements IService {
                 .end(jo.encode());
     }
 
-    private void handleListAllAllowlist(RoutingContext rc) {
+    private void handleListAllAllowedSites(RoutingContext rc) {
         try {
             JsonArray ja = new JsonArray();
             Map<Integer, Keyset> collection = this.keysetProvider.getSnapshot().getAllKeysets();
@@ -222,7 +222,7 @@ public class SharingService implements IService {
                 JsonObject jo = new JsonObject();
                 jo.put("keyset_id", keyset.getValue().getKeysetId());
                 jo.put("site_id", keyset.getValue().getSiteId());
-                jo.put("allowlist", listedSites);
+                jo.put("allowed_sites", listedSites);
                 jo.put("hash", keyset.getValue().hashCode());
                 ja.add(jo);
             }
@@ -235,7 +235,7 @@ public class SharingService implements IService {
         }
     }
 
-    private void handleSetAllowlist(RoutingContext rc) {
+    private void handleSetAllowedSites(RoutingContext rc) {
         synchronized (writeLock) {
            int siteId;
            try {
@@ -259,7 +259,7 @@ public class SharingService implements IService {
 
            final JsonObject body = rc.body().asJsonObject();
 
-           final JsonArray whitelist = body.getJsonArray("allowlist");
+           final JsonArray whitelist = body.getJsonArray("allowed_sites");
            final int hash = body.getInteger("hash");
 
            if (keyset != null &&  hash != keyset.hashCode()) {
@@ -296,7 +296,7 @@ public class SharingService implements IService {
            }
 
            JsonObject jo = new JsonObject();
-           jo.put("allowlist", whitelist);
+           jo.put("allowed_sites", whitelist);
            jo.put("hash", newKeyset.hashCode());
 
            rc.response()

--- a/src/main/resources/localstack/s3/keysets/keysets.json
+++ b/src/main/resources/localstack/s3/keysets/keysets.json
@@ -2,7 +2,7 @@
   {
     "keyset_id" : 1,
     "site_id": -1,
-    "name" : "My keyset",
+    "name" : "Master",
     "allowed_sites" : [],
     "created" : 1617149276,
     "enabled" : true,
@@ -11,7 +11,7 @@
   {
     "keyset_id" : 2,
     "site_id": -2,
-    "name" : "My keyset",
+    "name" : "Refresh",
     "allowed_sites" : [5, 7, 8, 9],
     "created" : 1617149276,
     "enabled" : true,
@@ -20,7 +20,7 @@
   {
     "keyset_id" : 3,
     "site_id": 2,
-    "name" : "My keyset",
+    "name" : "Fallback Publisher",
     "allowed_sites" : [5, 7, 8, 9],
     "created" : 1617149276,
     "enabled" : true,

--- a/src/test/java/com/uid2/admin/util/KeysetUtilTest.java
+++ b/src/test/java/com/uid2/admin/util/KeysetUtilTest.java
@@ -2,14 +2,15 @@ package com.uid2.admin.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.uid2.shared.Const;
 import com.uid2.shared.auth.Keyset;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Map;
 
-import static com.uid2.admin.util.KeysetUtil.getMaxKeyset;
-import static com.uid2.admin.util.KeysetUtil.lookUpKeyset;
+import static com.uid2.admin.util.KeysetUtil.*;
+import static com.uid2.admin.util.KeysetUtil.createDefaultKeyset;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -64,5 +65,39 @@ public class KeysetUtilTest {
                 4, new Keyset(4, 3, "", new HashSet<>(), 0, true, true)
         );
         assertEquals(4, getMaxKeyset(fourKeysets));
+    }
+
+    @Test
+    public void testKeysetNameCreation() {
+
+        //expected cases of special keysets when site id and keyset id match our expectations
+        Keyset keyset = createDefaultKeyset(-1, 1);
+        assertEquals(keyset.getName(), Const.Data.MasterKeysetName);
+        keyset = createDefaultKeyset(-2, 2);
+        assertEquals(keyset.getName(), Const.Data.RefreshKeysetName);
+        keyset = createDefaultKeyset(2, 3);
+        assertEquals(keyset.getName(), Const.Data.FallbackPublisherKeysetName);
+
+        //only site id matches but keyset id aren't the same as what we expected
+        keyset = createDefaultKeyset(-1, 3);
+        assertEquals(keyset.getName(), "");
+        keyset = createDefaultKeyset(-2, 34);
+        assertEquals(keyset.getName(), "");
+        keyset = createDefaultKeyset(2, 56);
+        assertEquals(keyset.getName(), "");
+
+        //only keyset id matches but site Id aren't the same as what we expected
+        keyset = createDefaultKeyset(-5, 1);
+        assertEquals(keyset.getName(), "");
+        keyset = createDefaultKeyset(-3, 2);
+        assertEquals(keyset.getName(), "");
+        keyset = createDefaultKeyset(20, 3);
+        assertEquals(keyset.getName(), "");
+
+        //for any other normal keyset creation
+        keyset = createDefaultKeyset(6, 7);
+        assertEquals(keyset.getName(), "");
+        keyset = createDefaultKeyset(9, 23);
+        assertEquals(keyset.getName(), "");
     }
 }

--- a/src/test/java/com/uid2/admin/util/KeysetUtilTest.java
+++ b/src/test/java/com/uid2/admin/util/KeysetUtilTest.java
@@ -72,11 +72,11 @@ public class KeysetUtilTest {
 
         //expected cases of special keysets when site id and keyset id match our expectations
         Keyset keyset = createDefaultKeyset(-1, 1);
-        assertEquals(keyset.getName(), Const.Data.MasterKeysetName);
+        assertEquals(keyset.getName(), KeysetUtil.MasterKeysetName);
         keyset = createDefaultKeyset(-2, 2);
-        assertEquals(keyset.getName(), Const.Data.RefreshKeysetName);
+        assertEquals(keyset.getName(), KeysetUtil.RefreshKeysetName);
         keyset = createDefaultKeyset(2, 3);
-        assertEquals(keyset.getName(), Const.Data.FallbackPublisherKeysetName);
+        assertEquals(keyset.getName(), KeysetUtil.FallbackPublisherKeysetName);
 
         //only site id matches but keyset id aren't the same as what we expected
         keyset = createDefaultKeyset(-1, 3);

--- a/src/test/java/com/uid2/admin/util/KeysetUtilTest.java
+++ b/src/test/java/com/uid2/admin/util/KeysetUtilTest.java
@@ -1,11 +1,14 @@
 package com.uid2.admin.util;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.uid2.shared.auth.Keyset;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Map;
 
+import static com.uid2.admin.util.KeysetUtil.getMaxKeyset;
 import static com.uid2.admin.util.KeysetUtil.lookUpKeyset;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -26,5 +29,40 @@ public class KeysetUtilTest {
 
         result = lookUpKeyset(4, keysets);
         assertNull(result);
+    }
+
+    // keyset id 1/2/3 are assigned for master/refresh/default publisher encryption key ids,
+    // so we always reserve these 3 keyset ids for them
+    @Test
+    public void testGetMaxKeyset() {
+        Map<Integer, Keyset> emptyKeysets = ImmutableMap.of();
+        assertEquals(3, getMaxKeyset(emptyKeysets));
+
+
+        Map<Integer, Keyset> singleKeyset = Map.of(
+                1, new Keyset(1, 1, "", new HashSet<>(), 0, true, true)
+        );
+        assertEquals(3, getMaxKeyset(singleKeyset));
+
+        Map<Integer, Keyset> twoKeysets = Map.of(
+                1, new Keyset(1, -1, "", new HashSet<>(), 0, true, true),
+                2, new Keyset(2, -2, "", new HashSet<>(), 0, true, false)
+        );
+        assertEquals(3, getMaxKeyset(twoKeysets));
+
+        Map<Integer, Keyset> threeKeysets = Map.of(
+                1, new Keyset(1, -1, "", new HashSet<>(), 0, true, true),
+                2, new Keyset(2, -2, "", new HashSet<>(), 0, true, false),
+                3, new Keyset(3, 2, "", new HashSet<>(), 0, true, true)
+        );
+        assertEquals(3, getMaxKeyset(threeKeysets));
+
+        Map<Integer, Keyset> fourKeysets = Map.of(
+                1, new Keyset(1, -1, "", new HashSet<>(), 0, true, true),
+                2, new Keyset(2, -2, "", new HashSet<>(), 0, true, false),
+                3, new Keyset(3, 2, "", new HashSet<>(), 0, true, true),
+                4, new Keyset(4, 3, "", new HashSet<>(), 0, true, true)
+        );
+        assertEquals(4, getMaxKeyset(fourKeysets));
     }
 }

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
@@ -154,10 +154,10 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         setEncryptionKeys(123);
         setKeysetKeys(123);
         final EncryptionKey key = keyService.addSiteKey(5);
-
-        Keyset expected = new Keyset(2, 5, "", null, Instant.now().getEpochSecond(), true, true);
-        assertNotNull(keysets.get(2));
-        assertTrue(keysets.get(2).equals(expected));
+        
+        Keyset expected = new Keyset(4, 5, "", null, Instant.now().getEpochSecond(), true, true);
+        assertNotNull(keysets.get(4));
+        assertTrue(keysets.get(4).equals(expected));
         verify(keysetKeyStoreWriter).upload(collectionOfSize(1), eq(124));
     }
 
@@ -795,6 +795,9 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
                 new EncryptionKey(12, null, Instant.ofEpochMilli(KEY_CREATE_TIME_IN_MILLI+1), clock.now().plusSeconds(MASTER_KEY_ACTIVATES_IN_SECONDS + A_HUNDRED_DAYS_IN_SECONDS), clock.now().plusSeconds(MASTER_KEY_EXPIRES_AFTER_SECONDS + A_HUNDRED_DAYS_IN_SECONDS), 5),
                 new EncryptionKey(13, null, Instant.ofEpochMilli(KEY_CREATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_ACTIVATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_EXPIRE_TIME_IN_MILLI), 6),
                 new EncryptionKey(14, null, Instant.ofEpochMilli(KEY_CREATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_ACTIVATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_EXPIRE_TIME_IN_MILLI), 7),
+                new EncryptionKey(15, null, Instant.ofEpochMilli(KEY_CREATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_ACTIVATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_EXPIRE_TIME_IN_MILLI), -1),
+                new EncryptionKey(16, null, Instant.ofEpochMilli(KEY_CREATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_ACTIVATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_EXPIRE_TIME_IN_MILLI), -2),
+                new EncryptionKey(17, null, Instant.ofEpochMilli(KEY_CREATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_ACTIVATE_TIME_IN_MILLI), Instant.ofEpochMilli(KEY_EXPIRE_TIME_IN_MILLI), 2),
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
         Map<Integer, Keyset> keysets = new HashMap<Integer, Keyset>() {{
@@ -803,10 +806,17 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         final KeysetKey[] keysetKeys = {};
         setKeysetKeys(0, keysetKeys);
         keyService.createKeysetKeys();
-        // 4 keys should be added
-        verify(keysetKeyStoreWriter).upload(collectionOfSize(4), eq(777));
-        // 3 keysets should be created
-        assertEquals(3, keysets.keySet().size());
+        // 7 keys should be added
+        verify(keysetKeyStoreWriter).upload(collectionOfSize(7), eq(777));
+        // 6 keysets should be created
+        assertEquals(6, keysets.keySet().size());
+        //Special Keysets are set correctly
+        // Master key site id -1 : keyset id 1
+        assertEquals(-1, keysets.get(1).getSiteId());
+        // Master key site id -2 : keyset id 2
+        assertEquals(-2, keysets.get(2).getSiteId());
+        // Master key site id 2 : keyset id 3
+        assertEquals(2, keysets.get(3).getSiteId());
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
@@ -53,7 +53,7 @@ public class SharingServiceTest extends ServiceTestBase {
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
 
-            compareKeysetToResult(keysets.get(1), response.bodyAsJsonObject().getJsonArray("allowlist"));
+            compareKeysetToResult(keysets.get(1), response.bodyAsJsonObject().getJsonArray("allowed_sites"));
 
             Integer expectedHash = keysets.get(1).hashCode();
             assertEquals(expectedHash, response.bodyAsJsonObject().getInteger("hash"));
@@ -94,7 +94,7 @@ public class SharingServiceTest extends ServiceTestBase {
         setKeysets(keysets);
 
         String body = "  {\n" +
-                "    \"allowlist\": [\n" +
+                "    \"allowed_sites\": [\n" +
                 "      22,\n" +
                 "      25,\n" +
                 "      6\n" +
@@ -108,7 +108,7 @@ public class SharingServiceTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
 
             Keyset expected = new Keyset(1, 5, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true);
-            compareKeysetToResult(expected, response.bodyAsJsonObject().getJsonArray("allowlist"));
+            compareKeysetToResult(expected, response.bodyAsJsonObject().getJsonArray("allowed_sites"));
 
             assertEquals(expected.getAllowedSites(), keysets.get(1).getAllowedSites());
             testContext.completeNow();
@@ -128,7 +128,7 @@ public class SharingServiceTest extends ServiceTestBase {
         setKeysets(keysets);
 
         String body = "  {\n" +
-                "    \"allowlist\": [\n" +
+                "    \"allowed_sites\": [\n" +
                 "      22,\n" +
                 "      25,\n" +
                 "      6\n" +
@@ -142,7 +142,7 @@ public class SharingServiceTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
 
             Keyset expected = new Keyset(4, 8, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true);
-            compareKeysetToResult(expected, response.bodyAsJsonObject().getJsonArray("allowlist"));
+            compareKeysetToResult(expected, response.bodyAsJsonObject().getJsonArray("allowed_sites"));
 
             assertEquals(expected.getAllowedSites(), keysets.get(4).getAllowedSites());
 
@@ -169,7 +169,7 @@ public class SharingServiceTest extends ServiceTestBase {
         setKeysets(keysets);
 
         String body1 = "  {\n" +
-                "    \"allowlist\": [\n" +
+                "    \"allowed_sites\": [\n" +
                 "      22,\n" +
                 "      25,\n" +
                 "      6\n" +
@@ -178,7 +178,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "  }";
 
         String body2 = "  {\n" +
-                "    \"allowlist\": [\n" +
+                "    \"allowed_sites\": [\n" +
                 "      2,\n" +
                 "      5,\n" +
                 "      6\n" +
@@ -228,7 +228,7 @@ public class SharingServiceTest extends ServiceTestBase {
             for (int i = 0; i < keysets.size(); i++) {
                 JsonObject resp = respArray.getJsonObject(i);
                 int keyset_id = resp.getInteger("keyset_id");
-                compareKeysetToResult(keysets.get(keyset_id), resp.getJsonArray("allowlist"));
+                compareKeysetToResult(keysets.get(keyset_id), resp.getJsonArray("allowed_sites"));
 
                 Integer expectedHash = keysets.get(keyset_id).hashCode();
                 assertEquals(expectedHash, resp.getInteger("hash"));
@@ -254,7 +254,7 @@ public class SharingServiceTest extends ServiceTestBase {
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
 
-            compareKeysetToResult(keysets.get(1), response.bodyAsJsonObject().getJsonArray("allowlist"));
+            compareKeysetToResult(keysets.get(1), response.bodyAsJsonObject().getJsonArray("allowed_sites"));
 
             testContext.completeNow();
         });
@@ -281,7 +281,7 @@ public class SharingServiceTest extends ServiceTestBase {
             for (int i = 0; i < keysets.size(); i++) {
                 JsonObject resp = respArray.getJsonObject(i);
                 int keyset_id = resp.getInteger("keyset_id");
-                compareKeysetToResult(keysets.get(keyset_id), resp.getJsonArray("allowlist"));
+                compareKeysetToResult(keysets.get(keyset_id), resp.getJsonArray("allowed_sites"));
             }
 
             testContext.completeNow();
@@ -301,7 +301,7 @@ public class SharingServiceTest extends ServiceTestBase {
         setKeysets(keysets);
 
         String body = "  {\n" +
-                "    \"allowlist\": [\n" +
+                "    \"allowed_sites\": [\n" +
                 "      22,\n" +
                 "      25,\n" +
                 "      6\n" +
@@ -316,7 +316,7 @@ public class SharingServiceTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
 
             Keyset expected = new Keyset(1, 5, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true);
-            compareKeysetToResult(expected, response.bodyAsJsonObject().getJsonArray("allowlist"));
+            compareKeysetToResult(expected, response.bodyAsJsonObject().getJsonArray("allowed_sites"));
 
             assertEquals(expected.getAllowedSites(), keysets.get(1).getAllowedSites());
             testContext.completeNow();
@@ -336,7 +336,7 @@ public class SharingServiceTest extends ServiceTestBase {
         setKeysets(keysets);
 
         String body = "  {\n" +
-                "    \"allowlist\": [\n" +
+                "    \"allowed_sites\": [\n" +
                 "      22,\n" +
                 "      25,\n" +
                 "      6\n" +
@@ -350,7 +350,7 @@ public class SharingServiceTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
 
             Keyset expected = new Keyset(4, 8, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true);
-            compareKeysetToResult(expected, response.bodyAsJsonObject().getJsonArray("allowlist"));
+            compareKeysetToResult(expected, response.bodyAsJsonObject().getJsonArray("allowed_sites"));
 
             assertEquals(expected.getAllowedSites(), keysets.get(4).getAllowedSites());
             testContext.completeNow();

--- a/webroot/adm/keysets.html
+++ b/webroot/adm/keysets.html
@@ -17,9 +17,9 @@
 <input type="text" id="siteId" name="siteId">
 <label for="keysetId">Keyset Id:</label>
 <input type="text" id="keysetId" name="keysetId">
-<label for="addSiteIds">Add Site Ids:</label>
+<label for="addSiteIds">Add Allowed Site Ids:</label>
 <input type="text" id="addSiteIds" name="addSiteIds">
-<label for="removeSiteIds">Remove Site Ids:</label>
+<label for="removeSiteIds">Remove Allowed Site Ids:</label>
 <input type="text" id="removeSiteIds" name="removeSiteIds">
 
 <br>

--- a/webroot/adm/keysets.html
+++ b/webroot/adm/keysets.html
@@ -63,7 +63,7 @@
         return
       }
       const url = '/api/sharing/keyset';
-      doApiCall('POST', url, '#standardOutput', 'errorOutput', JSON.stringify({allowlist: [], keyset_id : keysetId, site_id: siteId}))
+      doApiCall('POST', url, '#standardOutput', 'errorOutput', JSON.stringify({allowed_sites: [], keyset_id : keysetId, site_id: siteId}))
     });
 
     $('#doUpdate').on('click', function () {
@@ -76,15 +76,15 @@
 
       doApiCallWithCallback('GET', url, (text) => {
         const jo = JSON.parse(text);
-        let allowlist = jo.allowlist;
+        let allowedSites = jo.allowed_sites;
 
-        allowlist = allowlist.filter((value, _, __) => !remove.includes(value))
-        allowlist = allowlist.concat(add.filter((value, _, __) => !allowlist.includes(value)))
+        allowedSites = allowedSites.filter((value, _, __) => !remove.includes(value))
+        allowedSites = allowedSites.concat(add.filter((value, _, __) => !allowedSites.includes(value)))
 
         const url = '/api/sharing/keyset';
 
 
-        doApiCall('POST', url, '#standardOutput', 'errorOutput', JSON.stringify({allowlist: allowlist, keyset_id: keysetId, site_id: siteId}))
+        doApiCall('POST', url, '#standardOutput', 'errorOutput', JSON.stringify({allowed_sites: allowedSites, keyset_id: keysetId, site_id: siteId}))
       }, (err) => {
         $('#errorOutput').html('Error: ' + err.status + ': ' + err.statusText);
       });
@@ -93,7 +93,7 @@
     $('#doMakeNew').on('click', function () {
       const siteId = parseInt($('#siteId').val());
       const url = '/api/sharing/keyset';
-      doApiCall('POST', url, '#standardOutput', 'errorOutput', JSON.stringify({allowlist: [] ,site_id: siteId}));
+      doApiCall('POST', url, '#standardOutput', 'errorOutput', JSON.stringify({allowed_sites: [] ,site_id: siteId}));
     });
   });
 


### PR DESCRIPTION
1.  Change 'Add Site Ids' to 'Add Allowed Site Ids' and 'Remove Allowed Site Ids' to be less confusing
2. renamed all allowlists to allowed_sites
3.  Port Cody's changes from https://github.com/IABTechLab/uid2-admin/pull/97 to rebase off master
4. reserve right keyset id for special encryption keys