### PR TITLE
allow to add new enclave-id with gcp-oidc protocol

### DIFF
--- a/src/main/java/com/uid2/admin/vertx/RequestUtil.java
+++ b/src/main/java/com/uid2/admin/vertx/RequestUtil.java
@@ -1,5 +1,6 @@
 package com.uid2.admin.vertx;
 
+import com.google.common.collect.ImmutableSet;
 import com.uid2.admin.model.Site;
 import com.uid2.admin.store.reader.ISiteStore;
 import com.uid2.shared.auth.Role;
@@ -11,6 +12,14 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class RequestUtil {
+    private final static ImmutableSet<String> SupportedProtocols = ImmutableSet.of(
+            "trusted",
+            "aws-nitro",
+            "azure-sgx",
+            "gcp-vmid",
+            "gcp-oidc"
+    );
+
     public static String getRolesSpec(Set<Role> roles) {
         return String.join(",", roles.stream().map(r -> r.toString()).collect(Collectors.toList()));
     }
@@ -123,10 +132,10 @@ public class RequestUtil {
 
     public static String validateOperatorProtocol(String protocol) {
         protocol = protocol.toLowerCase();
-        if (!protocol.equals("trusted") && !protocol.equals("aws-nitro") && !protocol.equals("gcp-vmid") && !protocol.equals("azure-sgx"))
-            return null;
-        else
+        if (SupportedProtocols.contains(protocol)) {
             return protocol;
+        }
+        return null;
     }
 
     public static Duration getDuration(RoutingContext rc, String paramName) {


### PR DESCRIPTION
We have a hardcoded acceptable protocol lists. Add "gcp-oidc" to this list.

Verified locally:
![image](https://github.com/IABTechLab/uid2-admin/assets/137876002/6bd93920-31c5-448d-a731-01d7b767adf2)
