### PR TITLE
Expose data store version prometheus metrics

### DIFF
--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -7,6 +7,7 @@ import com.uid2.admin.auth.AuthFactory;
 import com.uid2.admin.job.JobDispatcher;
 import com.uid2.admin.job.jobsync.PrivateSiteDataSyncJob;
 import com.uid2.admin.managers.KeysetManager;
+import com.uid2.admin.monitoring.DataStoreMetrics;
 import com.uid2.admin.secret.*;
 import com.uid2.admin.store.*;
 import com.uid2.admin.store.reader.RotatingPartnerStore;
@@ -222,6 +223,20 @@ public class Main {
 
             AdminVerticle adminVerticle = new AdminVerticle(config, authFactory, adminUserProvider, services);
             vertx.deployVerticle(adminVerticle);
+
+            // Data type keys should be matching uid2_config_store_version reported by operator, core, etc
+            DataStoreMetrics.addDataStoreMetrics("admins", adminUserProvider);
+            DataStoreMetrics.addDataStoreMetrics("site", siteProvider);
+            DataStoreMetrics.addDataStoreMetrics("auth", clientKeyProvider);
+            DataStoreMetrics.addDataStoreMetrics("key", keyProvider);
+            DataStoreMetrics.addDataStoreMetrics("keys_acl", keyAclProvider);
+            DataStoreMetrics.addDataStoreMetrics("keyset", keysetProvider);
+            DataStoreMetrics.addDataStoreMetrics("keysetkey", keysetKeysProvider);
+            DataStoreMetrics.addDataStoreMetrics("cskeypair", clientSideKeypairProvider);
+            DataStoreMetrics.addDataStoreMetrics("operators", operatorKeyProvider);
+            DataStoreMetrics.addDataStoreMetrics("enclaves", enclaveIdProvider);
+            DataStoreMetrics.addDataStoreMetrics("salt", saltProvider);
+            DataStoreMetrics.addDataStoreMetrics("partners", partnerConfigProvider);
 
             //UID2-575 set up a job dispatcher that will write private site data periodically if there is any changes
             //check job for every minute

--- a/src/main/java/com/uid2/admin/monitoring/DataStoreMetrics.java
+++ b/src/main/java/com/uid2/admin/monitoring/DataStoreMetrics.java
@@ -1,0 +1,24 @@
+package com.uid2.admin.monitoring;
+
+import com.uid2.shared.store.reader.IMetadataVersionedStore;
+import io.micrometer.core.instrument.Gauge;
+
+import static io.micrometer.core.instrument.Metrics.globalRegistry;
+
+public final class DataStoreMetrics {
+
+    public static void addDataStoreMetrics(String dataType, IMetadataVersionedStore dataStore) {
+        Gauge
+                .builder("uid2_data_store_version", () -> {
+                    try {
+                        // Warning: this downloads metadata from the underlying remote data store
+                        return dataStore.getVersion(dataStore.getMetadata());
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .tag("store", dataType)
+                .description("version from metadata of a data store")
+                .register(globalRegistry);
+    }
+}

--- a/src/main/resources/localstack/s3/partners/metadata.json
+++ b/src/main/resources/localstack/s3/partners/metadata.json
@@ -1,4 +1,6 @@
 {
+  "version" : 1,
+  "generated" : 1670883129,
   "partners" : {
     "location" : "partners/partners.json"
   }


### PR DESCRIPTION
- add uid2_data_store_version metric per data store used by the admin service
- this can be used to compare the versions other (downstream) services are seeing and alert on mismatches