### PR TITLE
jyg-UID2 fix vertx tests

### DIFF
--- a/src/test/java/com/uid2/admin/vertx/AdminKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/AdminKeyServiceTest.java
@@ -56,18 +56,14 @@ public class AdminKeyServiceTest extends ServiceTestBase {
         AdminUser expectedAdminUser = this.expectedAdminUser();
 
         post(vertx, testContext, String.format("api/admin/add?name=%s&roles=administrator", expectedAdminUser.getName()), "", response -> {
-            try {
-                JsonObject result = response.bodyAsJsonObject();
+            JsonObject result = response.bodyAsJsonObject();
 
-                assertAll(
-                        "addAdminUsesKeyPrefixAndFormattedKeyString",
-                        () -> assertNotNull(result),
-                        () -> checkAdminUserJson(expectedAdminUser, result));
+            assertAll(
+                    "addAdminUsesKeyPrefixAndFormattedKeyString",
+                    () -> assertNotNull(result),
+                    () -> checkAdminUserJson(expectedAdminUser, result));
 
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
+            testContext.completeNow();
         });
     }
 

--- a/src/test/java/com/uid2/admin/vertx/AdminKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/AdminKeyServiceTest.java
@@ -55,14 +55,12 @@ public class AdminKeyServiceTest extends ServiceTestBase {
 
         AdminUser expectedAdminUser = this.expectedAdminUser();
 
-        post(vertx, String.format("api/admin/add?name=%s&roles=administrator", expectedAdminUser.getName()), "", response -> {
+        post(vertx, testContext, String.format("api/admin/add?name=%s&roles=administrator", expectedAdminUser.getName()), "", response -> {
             try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
+                JsonObject result = response.bodyAsJsonObject();
 
                 assertAll(
                         "addAdminUsesKeyPrefixAndFormattedKeyString",
-                        () -> assertTrue(response.succeeded()),
                         () -> assertNotNull(result),
                         () -> checkAdminUserJson(expectedAdminUser, result));
 

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -53,7 +53,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
 
-        post(vertx, testContext,"api/client/rename?oldName=test_client&newName=test_client1", "", ar -> {
+        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             ClientKey expected = new LegacyClientBuilder().withName("test_client1").build().toClientKey();
 

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -53,7 +53,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
 
-        post(vertx, "api/client/rename?oldName=test_client&newName=test_client1", "", ar -> {
+        post(vertx, testContext,"api/client/rename?oldName=test_client&newName=test_client1", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             ClientKey expected = new LegacyClientBuilder().withName("test_client1").build().toClientKey();
 
@@ -80,7 +80,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                 new LegacyClientBuilder().withName("test_client1").build()
         );
 
-        post(vertx, "api/client/rename?oldName=test_client&newName=test_client1", "", ar -> {
+        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "clientRenameWithExistingName",
@@ -96,7 +96,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
 
         LegacyClientKey expectedClient = new LegacyClientBuilder().withServiceId(145).build();
-        post(vertx, "api/client/add?name=test_client&roles=generator&site_id=5&service_id=145", "", ar -> {
+        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=5&service_id=145", "", ar -> {
             try {
                 HttpResponse<Buffer> response = ar.result();
                 RevealedKey<ClientKey> revealedClient = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
@@ -170,7 +170,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().withServiceId(165).build());
 
-        post(vertx, "api/client/update?name=test_client&site_id=5&service_id=200", "", ar -> {
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=5&service_id=200", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             ClientKey expected = new LegacyClientBuilder().withServiceId(200).build().toClientKey();
             try {

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -104,7 +104,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
 
         String endpoint = String.format("api/client/add?name=test_client&site_id=5&roles=%s", RequestUtil.getRolesSpec(roles));
-        post(vertx, endpoint, "", testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, endpoint, "", response -> {
             assertAll(
                     "clientAddCreatesSiteKeyIfNoneExists",
                     () -> assertEquals(200, response.statusCode()),
@@ -116,7 +116,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                     () -> verifyNoMoreInteractions(keysetKeyManager)
             );
             testContext.completeNow();
-        })));
+        });
     }
 
     private static Stream<Arguments> createSiteKeyIfNoneExistsTestData() {
@@ -132,19 +132,19 @@ public class ClientKeyServiceTest extends ServiceTestBase {
     @Test
     public void clientAddUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, "api/client/add?name=test_client&roles=generator&site_id=4", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=4", "", expectHttpError(testContext, 404));
     }
 
     @Test
     public void clientAddSpecialSiteId1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, "api/client/add?name=test_client&roles=generator&site_id=1", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=1", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void clientAddSpecialSiteId2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, "api/client/add?name=test_client&roles=generator&site_id=2", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=2", "", expectHttpError(testContext, 400));
     }
 
     @Test
@@ -176,7 +176,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                         .build()
         );
 
-        post(vertx, "api/client/update?name=test_client&site_id=5&service_id=145", "", testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=5&service_id=145", "", response -> {
             assertAll(
                     "clientUpdateCreatesSiteKeyIfNoneExists",
                     () -> assertEquals(200, response.statusCode()),
@@ -188,34 +188,34 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                     () -> verifyNoMoreInteractions(keysetKeyManager)
             );
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
     public void clientUpdateUnknownClientName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, "api/client/update?name=test_client&site_id=5", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=5", "", expectHttpError(testContext, 404));
     }
 
     @Test
     public void clientUpdateUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, "api/client/update?name=test_client&site_id=4", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=4", "", expectHttpError(testContext, 404));
     }
 
     @Test
     public void clientUpdateSpecialSiteId1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, "api/client/update?name=test_client&site_id=1", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=1", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void clientUpdateSpecialSiteId2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, "api/client/update?name=test_client&site_id=2", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=2", "", expectHttpError(testContext, 400));
     }
 
     @ParameterizedTest
@@ -225,7 +225,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         setClientKeys(new LegacyClientBuilder().build());
 
         String endpoint = String.format("api/client/roles?name=test_client&roles=%s", RequestUtil.getRolesSpec(roles));
-        post(vertx, endpoint, "", testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, endpoint, "", response -> {
             assertAll(
                     "createSiteKeyIfNoneExistsTestData",
                     () -> assertEquals(200, response.statusCode()),
@@ -237,7 +237,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                     () -> verifyNoMoreInteractions(keysetKeyManager)
             );
             testContext.completeNow();
-        })));
+        });
     }
 
     private static void assertAddedClientKeyEquals(ClientKey expected, ClientKey actual) {

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -53,21 +53,14 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
 
-        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", response -> {
             ClientKey expected = new LegacyClientBuilder().withName("test_client1").build().toClientKey();
-
-            try {
-                assertAll(
-                        "clientRename",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertEquals(expected, OBJECT_MAPPER.readValue(response.bodyAsString(), ClientKey.class)),
-                        () -> verify(legacyClientKeyStoreWriter).upload(collectionOfSize(1), isNull())
-                );
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "clientRename",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertEquals(expected, OBJECT_MAPPER.readValue(response.bodyAsString(), ClientKey.class)),
+                    () -> verify(legacyClientKeyStoreWriter).upload(collectionOfSize(1), isNull())
+            );
             testContext.completeNow();
         });
     }
@@ -80,13 +73,8 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                 new LegacyClientBuilder().withName("test_client1").build()
         );
 
-        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
-            assertAll(
-                    "clientRenameWithExistingName",
-                    () -> assertTrue(ar.succeeded()),
-                    () -> assertEquals(400, response.statusCode())
-            );
+        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", response -> {
+            assertEquals(400, response.statusCode());
             testContext.completeNow();
         });
     }
@@ -96,22 +84,16 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
 
         LegacyClientKey expectedClient = new LegacyClientBuilder().withServiceId(145).build();
-        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=5&service_id=145", "", ar -> {
-            try {
-                HttpResponse<Buffer> response = ar.result();
-                RevealedKey<ClientKey> revealedClient = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
+        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=5&service_id=145", "", response -> {
+            RevealedKey<ClientKey> revealedClient = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
 
-                assertAll(
-                        "clientAdd",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertAddedClientKeyEquals(expectedClient.toClientKey(), revealedClient.getAuthorizable()),
-                        () -> assertNotNull(revealedClient.getPlaintextKey()),
-                        () -> verify(legacyClientKeyStoreWriter).upload(collectionOfSize(1), isNull())
-                );
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "clientAdd",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertAddedClientKeyEquals(expectedClient.toClientKey(), revealedClient.getAuthorizable()),
+                    () -> assertNotNull(revealedClient.getPlaintextKey()),
+                    () -> verify(legacyClientKeyStoreWriter).upload(collectionOfSize(1), isNull())
+            );
             testContext.completeNow();
         });
     }
@@ -170,20 +152,14 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().withServiceId(165).build());
 
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=5&service_id=200", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=5&service_id=200", "", response -> {
             ClientKey expected = new LegacyClientBuilder().withServiceId(200).build().toClientKey();
-            try {
-                assertAll(
-                        "clientUpdate",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertEquals(expected, OBJECT_MAPPER.readValue(response.bodyAsString(), ClientKey.class)),
-                        () -> verify(legacyClientKeyStoreWriter).upload(collectionOfSize(1), isNull())
-                );
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "clientUpdate",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertEquals(expected, OBJECT_MAPPER.readValue(response.bodyAsString(), ClientKey.class)),
+                    () -> verify(legacyClientKeyStoreWriter).upload(collectionOfSize(1), isNull())
+            );
             testContext.completeNow();
         });
     }

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -13,8 +13,6 @@ import com.uid2.shared.auth.Role;
 import com.uid2.shared.model.Site;
 import com.uid2.shared.util.Mapper;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.VertxTestContext;
 import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,10 +71,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                 new LegacyClientBuilder().withName("test_client1").build()
         );
 
-        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", response -> {
-            assertEquals(400, response.statusCode());
-            testContext.completeNow();
-        });
+        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -132,19 +127,19 @@ public class ClientKeyServiceTest extends ServiceTestBase {
     @Test
     public void clientAddUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=4", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=4", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
     public void clientAddSpecialSiteId1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=1", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=1", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void clientAddSpecialSiteId2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=2", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/client/add?name=test_client&roles=generator&site_id=2", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -194,28 +189,28 @@ public class ClientKeyServiceTest extends ServiceTestBase {
     @Test
     public void clientUpdateUnknownClientName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=5", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=5", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
     public void clientUpdateUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=4", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=4", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
     public void clientUpdateSpecialSiteId1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=1", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=1", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void clientUpdateSpecialSiteId2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=2", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/client/update?name=test_client&site_id=2", "", expectHttpStatus(testContext, 400));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
@@ -95,14 +95,14 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
 
         setKeypairs(new ArrayList<>());
 
-        get(vertx, "api/client_side_keypairs/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/client_side_keypairs/list", response -> {
             assertEquals(200, response.statusCode());
 
             JsonArray respArray = response.bodyAsJsonArray();
             assertEquals(0, respArray.size());
 
             testContext.completeNow();
-        })));
+        });
     }
     @Test
     void listAll(Vertx vertx, VertxTestContext testContext) throws Exception {
@@ -116,14 +116,14 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         }};
         setKeypairs(new ArrayList<>(expectedKeypairs.values()));
 
-        get(vertx, "api/client_side_keypairs/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/client_side_keypairs/list", response -> {
             assertEquals(200, response.statusCode());
 
             JsonArray respArray = response.bodyAsJsonArray();
             validateResponseKeypairs(expectedKeypairs, respArray);
 
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -132,11 +132,11 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
 
         setKeypairs(new ArrayList<>());
 
-        get(vertx, "api/client_side_keypairs/aZ23456789").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/client_side_keypairs/aZ23456789", response -> {
             assertEquals(404, response.statusCode());
             assertEquals("Failed to find a keypair for subscription id: aZ23456789", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -153,13 +153,13 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         }};
         setKeypairs(new ArrayList<>(expectedKeypairs.values()));
 
-        get(vertx, "api/client_side_keypairs/aZ23456789").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/client_side_keypairs/aZ23456789", response -> {
             assertEquals(200, response.statusCode());
 
             validateKeypairWithPrivateKey(queryKeypair, response.bodyAsJsonObject());
 
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
@@ -95,7 +95,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
 
         setKeypairs(new ArrayList<>());
 
-        get(vertx, "api/client_side_keypairs/list", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/client_side_keypairs/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.statusCode());
 
             JsonArray respArray = response.bodyAsJsonArray();
@@ -116,7 +116,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         }};
         setKeypairs(new ArrayList<>(expectedKeypairs.values()));
 
-        get(vertx, "api/client_side_keypairs/list", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/client_side_keypairs/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.statusCode());
 
             JsonArray respArray = response.bodyAsJsonArray();
@@ -132,7 +132,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
 
         setKeypairs(new ArrayList<>());
 
-        get(vertx, "api/client_side_keypairs/aZ23456789", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/client_side_keypairs/aZ23456789").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(404, response.statusCode());
             assertEquals("Failed to find a keypair for subscription id: aZ23456789", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -153,7 +153,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         }};
         setKeypairs(new ArrayList<>(expectedKeypairs.values()));
 
-        get(vertx, "api/client_side_keypairs/aZ23456789", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/client_side_keypairs/aZ23456789").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.statusCode());
 
             validateKeypairWithPrivateKey(queryKeypair, response.bodyAsJsonObject());

--- a/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
@@ -176,12 +176,12 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
 
         JsonObject jo = new JsonObject();
 
-        post(vertx, "api/client_side_keypairs/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/add", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Required parameters: site_id", response.bodyAsJsonObject().getString("message"));
             verify(keypairStoreWriter, times(0)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -199,12 +199,12 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         JsonObject jo = new JsonObject();
         jo.put("contact", "email@email.com");
 
-        post(vertx, "api/client_side_keypairs/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/add", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Required parameters: site_id", response.bodyAsJsonObject().getString("message"));
             verify(keypairStoreWriter, times(0)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -223,12 +223,12 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("site_id", 123);
         jo.put("contact", "contact@gmail.com");
 
-        post(vertx, "api/client_side_keypairs/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/add", jo.encode(), response -> {
             assertEquals(404, response.statusCode());
             assertEquals("site_id: 123 not valid", response.bodyAsJsonObject().getString("message"));
             verify(keypairStoreWriter, times(0)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -248,7 +248,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("site_id", 123);
         jo.put("contact", "email@email.com");
 
-        post(vertx, "api/client_side_keypairs/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/add", jo.encode(), response -> {
             final ArgumentCaptor<Integer> siteId = ArgumentCaptor.forClass(Integer.class);
             try {
                 verify(this.keysetManager).createKeysetForSite(siteId.capture());
@@ -271,7 +271,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
             assertEquals(false, resp.getBoolean("disabled"));
             verify(keypairStoreWriter, times(1)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -290,7 +290,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         JsonObject jo = new JsonObject();
         jo.put("site_id", 123);
 
-        post(vertx, "api/client_side_keypairs/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/add", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             JsonObject resp = response.bodyAsJsonObject();
             assertEquals(123, resp.getInteger("site_id"));
@@ -307,7 +307,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
             assertEquals(false, resp.getBoolean("disabled"));
             verify(keypairStoreWriter, times(1)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -328,7 +328,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("contact", "email@email.com");
         jo.put("disabled", true);
 
-        post(vertx, "api/client_side_keypairs/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/add", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             JsonObject resp = response.bodyAsJsonObject();
             assertEquals(123, resp.getInteger("site_id"));
@@ -342,7 +342,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
             assertEquals(true, resp.getBoolean("disabled"));
             verify(keypairStoreWriter, times(1)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -362,12 +362,12 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("contact", "email@email.com");
         jo.put("disabled", true);
 
-        post(vertx, "api/client_side_keypairs/update", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/update", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Required parameters: subscription_id", response.bodyAsJsonObject().getString("message"));
             verify(keypairStoreWriter, times(0)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -388,12 +388,12 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("contact", "email@email.com");
         jo.put("disabled", true);
 
-        post(vertx, "api/client_side_keypairs/update", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/update", jo.encode(), response -> {
             assertEquals(404, response.statusCode());
             assertEquals("Failed to find a keypair for subscription id: bad-id", response.bodyAsJsonObject().getString("message"));
             verify(keypairStoreWriter, times(0)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -412,12 +412,12 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         JsonObject jo = new JsonObject();
         jo.put("subscription_id", "89aZ234567");
 
-        post(vertx, "api/client_side_keypairs/update", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/update", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Updatable parameters: contact, disabled, name", response.bodyAsJsonObject().getString("message"));
             verify(keypairStoreWriter, times(0)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -438,13 +438,13 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("subscription_id", "89aZ234567");
         jo.put("contact", "updated@email.com");
 
-        post(vertx, "api/client_side_keypairs/update", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/update", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             ClientSideKeypair expected = new ClientSideKeypair("89aZ234567", pub1, priv1, 124, "updated@email.com", time, true, name1);
             validateKeypair(expected, response.bodyAsJsonObject());
             verify(keypairStoreWriter, times(1)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -465,13 +465,13 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("subscription_id", "89aZ234567");
         jo.put("name", "updated name");
 
-        post(vertx, "api/client_side_keypairs/update", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/update", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             ClientSideKeypair expected = new ClientSideKeypair("89aZ234567", pub1, priv1, 124, "test-two@example.com", time, true, "updated name");
             validateKeypair(expected, response.bodyAsJsonObject());
             verify(keypairStoreWriter, times(1)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -492,13 +492,13 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("subscription_id", "89aZ234567");
         jo.put("disabled", false);
 
-        post(vertx, "api/client_side_keypairs/update", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/update", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             ClientSideKeypair expected = new ClientSideKeypair("89aZ234567", pub1, priv1, 124, "test-two@example.com", time, false, name1);
             validateKeypair(expected, response.bodyAsJsonObject());
             verify(keypairStoreWriter, times(1)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -520,13 +520,13 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("contact", "updated@email.com");
         jo.put("disabled", false);
 
-        post(vertx, "api/client_side_keypairs/update", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/update", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             ClientSideKeypair expected = new ClientSideKeypair("89aZ234567", pub1, priv1, 124, "updated@email.com", time, false, name1);
             validateKeypair(expected, response.bodyAsJsonObject());
             verify(keypairStoreWriter, times(1)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -548,13 +548,13 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         jo.put("name", "updated name");
         jo.put("disabled", false);
 
-        post(vertx, "api/client_side_keypairs/update", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/client_side_keypairs/update", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             ClientSideKeypair expected = new ClientSideKeypair("89aZ234567", pub1, priv1, 124, "test-two@example.com", time, false, "updated name");
             validateKeypair(expected, response.bodyAsJsonObject());
             verify(keypairStoreWriter, times(1)).upload(any(), isNull());
             testContext.completeNow();
-        })));
+        });
     }
 }
 

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
@@ -199,10 +199,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -221,10 +221,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -245,10 +245,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -269,10 +269,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -291,10 +291,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
             verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -313,10 +313,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -335,10 +335,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -357,10 +357,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
 
@@ -378,10 +378,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
             verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -400,10 +400,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -473,10 +473,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -496,10 +496,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -522,10 +522,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+2), eq(MAX_KEY_ID+2));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -548,10 +548,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
             verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+4), eq(MAX_KEY_ID+4));
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -568,10 +568,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
             verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -584,9 +584,9 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
             verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 }

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
@@ -193,18 +193,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -1 },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -221,18 +215,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -2 },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -251,18 +239,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -1, },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -281,18 +263,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -2 },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -311,16 +287,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
-            try {
-                verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -337,18 +307,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -1, },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -365,18 +329,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -2 },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -393,18 +351,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 5 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -422,16 +374,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
-            try {
-                verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -448,18 +394,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100&force=true", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100&force=true", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 5 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -518,18 +458,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 2 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -547,18 +481,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 2 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -579,18 +507,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 6, 7 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+2), eq(MAX_KEY_ID+2));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+2), eq(MAX_KEY_ID+2));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -611,18 +533,12 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100&force=true", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100&force=true", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 2, 5, 6, 7 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+4), eq(MAX_KEY_ID+4));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+4), eq(MAX_KEY_ID+4));
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -639,16 +555,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
-            try {
-                verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);
@@ -661,16 +571,10 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
-            try {
-                verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
             testContext.completeNow();
         });
         verifyNoInteractions(keysetStoreWriter);

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
@@ -149,7 +149,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
     void listKeysNoKeys(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.SECRET_MANAGER);
 
-        get(vertx, "api/key/list", ar -> {
+        get(vertx, testContext, "api/key/list", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -172,7 +172,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        get(vertx, "api/key/list", ar -> {
+        get(vertx, testContext, "api/key/list", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -193,7 +193,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -221,7 +221,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -251,7 +251,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -281,7 +281,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -311,7 +311,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -337,7 +337,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -365,7 +365,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -393,7 +393,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -422,7 +422,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -448,7 +448,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=5&min_age_seconds=100&force=true", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100&force=true", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -518,7 +518,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -547,7 +547,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -579,7 +579,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -611,7 +611,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100&force=true", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100&force=true", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -639,7 +639,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -661,7 +661,7 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
@@ -149,15 +149,15 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
     void listKeysNoKeys(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.SECRET_MANAGER);
 
-        get(vertx, testContext, "api/key/list", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/key/list", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
+
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
+
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
     }
 
     @Test
@@ -172,15 +172,15 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        get(vertx, testContext, "api/key/list", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/key/list", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyResponse(keys, response.bodyAsJsonArray().stream().toArray());
+
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
             testContext.completeNow();
         });
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
+
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceKeysetsDisabledTest.java
@@ -412,10 +412,13 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID);
 
-        post(vertx, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", expectHttpError(testContext, 404));
-        verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", response -> {
+            assertEquals(404, response.statusCode());
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
+            testContext.completeNow();
+        });
     }
 
     @Test
@@ -428,10 +431,13 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=-1&min_age_seconds=100", "", expectHttpError(testContext, 400));
-        verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
+        post(vertx, testContext, "api/key/rotate_site?site_id=-1&min_age_seconds=100", "", response -> {
+            assertEquals(400, response.statusCode());
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
+            testContext.completeNow();
+        });
     }
 
     @Test
@@ -443,10 +449,13 @@ public class EncryptionKeyServiceKeysetsDisabledTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=-1&min_age_seconds=100", "", expectHttpError(testContext, 400));
-        verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-        verifyNoInteractions(keysetStoreWriter);
-        verifyNoInteractions(keysetKeyStoreWriter);
+        post(vertx, testContext, "api/key/rotate_site?site_id=-1&min_age_seconds=100", "", response -> {
+            assertEquals(400, response.statusCode());
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            verifyNoInteractions(keysetStoreWriter);
+            verifyNoInteractions(keysetKeyStoreWriter);
+            testContext.completeNow();
+        });
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
@@ -204,7 +204,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
     void listKeysNoKeys(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.SECRET_MANAGER);
 
-        get(vertx, "api/key/list", ar -> {
+        get(vertx, testContext, "api/key/list", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -225,7 +225,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        get(vertx, "api/key/list", ar -> {
+        get(vertx, testContext, "api/key/list", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -246,7 +246,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setKeysetKeys(MAX_KEY_ID);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -273,7 +273,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -302,7 +302,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -330,7 +330,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -358,7 +358,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -382,7 +382,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -408,7 +408,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -434,7 +434,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -465,7 +465,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         }};
         setAdminKeysets(keysets);
 
-        post(vertx, "api/key/rotate_keyset_key?keyset_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_keyset_key?keyset_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -494,7 +494,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -518,7 +518,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=5&min_age_seconds=100&force=true", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100&force=true", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -580,7 +580,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -607,7 +607,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -637,7 +637,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -676,7 +676,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setKeysetKeys(MAX_KEY_ID, keysetKeys);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -707,7 +707,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100&force=true", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100&force=true", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -733,7 +733,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -753,7 +753,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID);
 
-        post(vertx, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
@@ -204,9 +204,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
     void listKeysNoKeys(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.SECRET_MANAGER);
 
-        get(vertx, testContext, "api/key/list", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/key/list", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
             testContext.completeNow();
@@ -225,9 +223,7 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        get(vertx, testContext, "api/key/list", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/key/list", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyResponse(keys, response.bodyAsJsonArray().stream().toArray());
             testContext.completeNow();

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
@@ -242,19 +242,13 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setKeysetKeys(MAX_KEY_ID);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -1 },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
-                verify(keysetKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
+            verify(keysetKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -269,19 +263,13 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -2 },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
-                verify(keysetKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
+            verify(keysetKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -298,18 +286,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -1, },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -326,18 +308,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -2 },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -354,16 +330,10 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
-            try {
-                verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
             testContext.completeNow();
         });
     }
@@ -378,18 +348,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -1, },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -404,18 +368,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_master?min_age_seconds=100&force=true", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { -2 },
                     MASTER_KEY_ACTIVATES_IN_SECONDS, MASTER_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(1)).upload(collectionOfSize(3), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -430,18 +388,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 5 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -461,21 +413,13 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         }};
         setAdminKeysets(keysets);
 
-        post(vertx, testContext, "api/key/rotate_keyset_key?keyset_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_keyset_key?keyset_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeysetKeyResponse(MAX_KEY_ID+1, new int[] { 5 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-
-            try {
-                verify(keysetKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(keysetKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -490,16 +434,10 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
-            try {
-                verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
             testContext.completeNow();
         });
     }
@@ -514,18 +452,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100&force=true", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100&force=true", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 5 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -576,18 +508,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 2 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -603,18 +529,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_site?site_id=2&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 2 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(1), eq(MAX_KEY_ID+1));
             testContext.completeNow();
         });
     }
@@ -633,19 +553,13 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 6, 7 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+2), eq(MAX_KEY_ID+2));
-                verify(keysetKeyStoreWriter).upload(collectionOfSize(2), eq(MAX_KEY_ID+2));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+2), eq(MAX_KEY_ID+2));
+            verify(keysetKeyStoreWriter).upload(collectionOfSize(2), eq(MAX_KEY_ID+2));
             testContext.completeNow();
         });
     }
@@ -672,19 +586,13 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setKeysetKeys(MAX_KEY_ID, keysetKeys);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 6, 7 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+2), eq(MAX_KEY_ID+2));
-                verify(keysetKeyStoreWriter).upload(collectionOfSize(keysetKeys.length+2), eq(MAX_KEY_ID+2));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+2), eq(MAX_KEY_ID+2));
+            verify(keysetKeyStoreWriter).upload(collectionOfSize(keysetKeys.length+2), eq(MAX_KEY_ID+2));
             testContext.completeNow();
         });
     }
@@ -703,18 +611,12 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100&force=true", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100&force=true", "", response -> {
             assertEquals(200, response.statusCode());
             checkRotatedKeyResponse(MAX_KEY_ID+1, new int[] { 2, 5, 6, 7 },
                     SITE_KEY_ACTIVATES_IN_SECONDS, SITE_KEY_EXPIRES_AFTER_SECONDS,
                     response.bodyAsJsonArray().stream().toArray());
-            try {
-                verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+4), eq(MAX_KEY_ID+4));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter).upload(collectionOfSize(keys.length+4), eq(MAX_KEY_ID+4));
             testContext.completeNow();
         });
     }
@@ -729,16 +631,10 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
-            try {
-                verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
             testContext.completeNow();
         });
     }
@@ -749,16 +645,10 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID);
 
-        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/key/rotate_all_sites?site_id=5&min_age_seconds=100", "", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
-            try {
-                verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
             testContext.completeNow();
         });
     }

--- a/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/EncryptionKeyServiceTest.java
@@ -468,8 +468,11 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
 
         setEncryptionKeys(MAX_KEY_ID);
 
-        post(vertx, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", expectHttpError(testContext, 404));
-        verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+        post(vertx, testContext, "api/key/rotate_site?site_id=5&min_age_seconds=100", "", response -> {
+            assertEquals(404, response.statusCode());
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            testContext.completeNow();
+        });
     }
 
     @Test
@@ -482,8 +485,11 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=-1&min_age_seconds=100", "", expectHttpError(testContext, 400));
-        verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+        post(vertx, testContext, "api/key/rotate_site?site_id=-1&min_age_seconds=100", "", response -> {
+            assertEquals(400, response.statusCode());
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            testContext.completeNow();
+        });
     }
 
     @Test
@@ -495,8 +501,11 @@ public class EncryptionKeyServiceTest extends ServiceTestBase {
         };
         setEncryptionKeys(MAX_KEY_ID, keys);
 
-        post(vertx, "api/key/rotate_site?site_id=-1&min_age_seconds=100", "", expectHttpError(testContext, 400));
-        verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+        post(vertx, testContext, "api/key/rotate_site?site_id=-1&min_age_seconds=100", "", response -> {
+            assertEquals(400, response.statusCode());
+            verify(encryptionKeyStoreWriter, times(0)).upload(any(), anyInt());
+            testContext.completeNow();
+        });
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
@@ -8,7 +8,6 @@ import com.uid2.shared.auth.Role;
 import com.uid2.shared.model.Site;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
@@ -164,28 +163,28 @@ public class KeyAclServiceTest extends ServiceTestBase {
     void keyAclResetUnknownSite(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
     void keyAclResetSpecialSite1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/keys_acl/reset?site_id=1&type=blacklist", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/reset?site_id=1&type=blacklist", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     void keyAclResetSpecialSite2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/keys_acl/reset?site_id=2&type=blacklist", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/reset?site_id=2&type=blacklist", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     void keyAclResetUnknownListType(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(5, "test_site", true));
-        post(vertx, testContext, "api/keys_acl/reset?site_id=2&type=unknown_list", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/reset?site_id=2&type=unknown_list", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -345,7 +344,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setSites(
                 new Site(5, "test_site", true),
                 new Site(11, "test_site11", true));
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
@@ -356,7 +355,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
             put(5, makeKeyAcl(false, 6, 7, 8));
         }};
         setEncryptionKeyAcls(initialAcls);
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=1", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=1", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -367,7 +366,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
             put(5, makeKeyAcl(false, 6, 7, 8));
         }};
         setEncryptionKeyAcls(initialAcls);
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=2", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=2", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -378,7 +377,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
             put(5, makeKeyAcl(false, 6, 7, 8));
         }};
         setEncryptionKeyAcls(initialAcls);
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", expectHttpStatus(testContext, 404));
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
@@ -44,7 +44,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
     void listKeyAclsNoAcls(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
 
-        get(vertx, "api/keys_acl/list", ar -> {
+        get(vertx, testContext, "api/keys_acl/list", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -65,7 +65,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
 
         setEncryptionKeyAcls(acls);
 
-        get(vertx, "api/keys_acl/list", ar -> {
+        get(vertx, testContext, "api/keys_acl/list", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -85,7 +85,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/reset?site_id=5&type=whitelist", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=whitelist", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -113,7 +113,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -143,7 +143,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -173,7 +173,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -231,7 +231,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -263,7 +263,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&add=11", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -295,7 +295,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&add=11", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -325,7 +325,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&remove=7", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=7", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -355,7 +355,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&remove=7", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=7", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -388,7 +388,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&add=11,12&remove=7,8", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11,12&remove=7,8", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -462,7 +462,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&add=7", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=7", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -492,7 +492,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&add=5", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=5", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -522,7 +522,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&add=5", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=5", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -552,7 +552,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, "api/keys_acl/update?site_id=5&remove=1,5,9,11", "", ar -> {
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=1,5,9,11", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());

--- a/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
@@ -164,28 +164,28 @@ public class KeyAclServiceTest extends ServiceTestBase {
     void keyAclResetUnknownSite(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/keys_acl/reset?site_id=5&type=blacklist", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", expectHttpError(testContext, 404));
     }
 
     @Test
     void keyAclResetSpecialSite1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/keys_acl/reset?site_id=1&type=blacklist", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/reset?site_id=1&type=blacklist", "", expectHttpError(testContext, 400));
     }
 
     @Test
     void keyAclResetSpecialSite2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/keys_acl/reset?site_id=2&type=blacklist", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/reset?site_id=2&type=blacklist", "", expectHttpError(testContext, 400));
     }
 
     @Test
     void keyAclResetUnknownListType(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(5, "test_site", true));
-        post(vertx, "api/keys_acl/reset?site_id=2&type=unknown_list", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/reset?site_id=2&type=unknown_list", "", expectHttpError(testContext, 400));
     }
 
     @Test
@@ -345,7 +345,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setSites(
                 new Site(5, "test_site", true),
                 new Site(11, "test_site11", true));
-        post(vertx, "api/keys_acl/update?site_id=5&add=11", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", expectHttpError(testContext, 404));
     }
 
     @Test
@@ -356,7 +356,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
             put(5, makeKeyAcl(false, 6, 7, 8));
         }};
         setEncryptionKeyAcls(initialAcls);
-        post(vertx, "api/keys_acl/update?site_id=5&add=1", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=1", "", expectHttpError(testContext, 400));
     }
 
     @Test
@@ -367,7 +367,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
             put(5, makeKeyAcl(false, 6, 7, 8));
         }};
         setEncryptionKeyAcls(initialAcls);
-        post(vertx, "api/keys_acl/update?site_id=5&add=2", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=2", "", expectHttpError(testContext, 400));
     }
 
     @Test
@@ -378,7 +378,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
             put(5, makeKeyAcl(false, 6, 7, 8));
         }};
         setEncryptionKeyAcls(initialAcls);
-        post(vertx, "api/keys_acl/update?site_id=5&add=11", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", expectHttpError(testContext, 404));
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
@@ -44,9 +44,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
     void listKeyAclsNoAcls(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
 
-        get(vertx, testContext, "api/keys_acl/list", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/keys_acl/list", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
             testContext.completeNow();
@@ -65,9 +63,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
 
         setEncryptionKeyAcls(acls);
 
-        get(vertx, testContext, "api/keys_acl/list", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/keys_acl/list", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(acls, response.bodyAsJsonArray().stream().toArray());
             testContext.completeNow();

--- a/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
@@ -81,19 +81,11 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=whitelist", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=whitelist", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
-
-            try {
-                verify(keyManager).addSiteKey(eq(5));
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(keyManager).addSiteKey(eq(5));
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
             testContext.completeNow();
         });
     }
@@ -109,18 +101,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager).addSiteKey(eq(5));
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager).addSiteKey(eq(5));
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
 
             testContext.completeNow();
         });
@@ -139,18 +125,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager).addSiteKey(eq(5));
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager).addSiteKey(eq(5));
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
 
             testContext.completeNow();
         });
@@ -169,18 +149,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/reset?site_id=5&type=blacklist", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager).addSiteKey(eq(5));
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager).addSiteKey(eq(5));
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
 
             testContext.completeNow();
         });
@@ -227,18 +201,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager, times(0)).addSiteKey(anyInt());
-                verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager, times(0)).addSiteKey(anyInt());
+            verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
 
             testContext.completeNow();
         });
@@ -259,18 +227,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager, times(0)).addSiteKey(anyInt());
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager, times(0)).addSiteKey(anyInt());
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
 
             testContext.completeNow();
         });
@@ -291,18 +253,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager).addSiteKey(eq(5));
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager).addSiteKey(eq(5));
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
 
             testContext.completeNow();
         });
@@ -321,18 +277,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=7", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=7", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager).addSiteKey(eq(5));
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager).addSiteKey(eq(5));
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
 
             testContext.completeNow();
         });
@@ -351,18 +301,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=7", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=7", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager, times(0)).addSiteKey(anyInt());
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager, times(0)).addSiteKey(anyInt());
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
 
             testContext.completeNow();
         });
@@ -384,18 +328,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11,12&remove=7,8", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=11,12&remove=7,8", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager).addSiteKey(eq(5));
-                verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager).addSiteKey(eq(5));
+            verify(keyAclStoreWriter).upload(mapOfSize(1), isNull());
 
             testContext.completeNow();
         });
@@ -458,18 +396,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=7", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=7", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager, times(0)).addSiteKey(anyInt());
-                verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager, times(0)).addSiteKey(anyInt());
+            verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
 
             testContext.completeNow();
         });
@@ -488,18 +420,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=5", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=5", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager, times(0)).addSiteKey(anyInt());
-                verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager, times(0)).addSiteKey(anyInt());
+            verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
 
             testContext.completeNow();
         });
@@ -518,18 +444,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=5", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&add=5", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager, times(0)).addSiteKey(anyInt());
-                verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager, times(0)).addSiteKey(anyInt());
+            verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
 
             testContext.completeNow();
         });
@@ -548,18 +468,12 @@ public class KeyAclServiceTest extends ServiceTestBase {
         setEncryptionKeyAcls(initialAcls);
         setEncryptionKeys(123);
 
-        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=1,5,9,11", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/keys_acl/update?site_id=5&remove=1,5,9,11", "", response -> {
             assertEquals(200, response.statusCode());
             checkEncryptionKeyAclsResponse(expectedAcl, new Object[]{response.bodyAsJsonObject()});
 
-            try {
-                verify(keyManager, times(0)).addSiteKey(anyInt());
-                verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keyManager, times(0)).addSiteKey(anyInt());
+            verify(keyAclStoreWriter, times(0)).upload(any(), isNull());
 
             testContext.completeNow();
         });

--- a/src/test/java/com/uid2/admin/vertx/OperatorKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/OperatorKeyServiceTest.java
@@ -12,8 +12,6 @@ import com.uid2.shared.auth.Role;
 import com.uid2.shared.model.Site;
 import com.uid2.shared.util.Mapper;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,7 +84,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
     @Test
     public void operatorAddUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, "api/operator/add?name=test_client&protocol=trusted&site_id=4&roles=optout", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=4&roles=optout", "", expectHttpError(testContext, 400));
     }
 
     @Test
@@ -128,25 +126,25 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
     @Test
     void operatorKeyAddInvalidRoleWithOperatorAndNonExistent(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,nonexistent", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,nonexistent", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void operatorKeyAddInvalidRoleCombinationWithOperatorAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout_service", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void operatorKeyAddInvalidRoleCombinationWithOptoutAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=optout,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=optout,optout_service", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void operatorKeyAddInvalidRoleCombinationWithOperatorAndOptoutAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout,optout_service", "", expectHttpError(testContext, 400));
     }
 
     @Test
@@ -173,7 +171,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
     public void operatorUpdateUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, "api/operator/update?name=test_client&site_id=4", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/operator/update?name=test_client&site_id=4", "", expectHttpError(testContext, 404));
     }
 
     @Test
@@ -221,42 +219,42 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
     public void operatorKeySetInvalidRoleCombinationWithOperatorAndNonexistent(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, "api/operator/roles?name=test_operator&roles=operator,nonexistent", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=operator,nonexistent", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void operatorKeySetInvalidRoleCombinationWithOperatorAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout_service", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void operatorKeySetInvalidRoleCombinationWithOptoutAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, "api/operator/roles?name=test_operator&roles=optout,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=optout,optout_service", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void operatorKeySetInvalidRoleCombinationWithOperatorptoutAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, "api/operator/roles?name=test_operator&roles=operator,optout,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=operator,optout,optout_service", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void operatorKeySetEmptyRole(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, "api/operator/roles?name=test_operator&roles=", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=", "", expectHttpError(testContext, 400));
     }
 
     @Test
     public void operatorKeySetRoleWithoutRoleParam(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, "api/operator/roles?name=test_operator", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator", "", expectHttpError(testContext, 400));
     }
 
     private static void assertAddedOperatorKeyEquals(OperatorKey expected, OperatorKey actual) {

--- a/src/test/java/com/uid2/admin/vertx/OperatorKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/OperatorKeyServiceTest.java
@@ -49,7 +49,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
                 .withRoles(Role.OPTOUT, Role.OPERATOR)
                 .withType(OperatorType.PUBLIC)
                 .build();
-        post(vertx, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=optout&operator_type=public", "", ar -> {
+        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=optout&operator_type=public", "", ar -> {
             try {
                 HttpResponse<Buffer> response = ar.result();
                 RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
@@ -76,7 +76,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
                 .withRoles(Role.OPTOUT, Role.OPERATOR)
                 .withType(OperatorType.PUBLIC)
                 .build();
-        post(vertx, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=optout&operator_type=public", "", ar -> {
+        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=optout&operator_type=public", "", ar -> {
             try {
                 HttpResponse<Buffer> response = ar.result();
                 RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
@@ -106,7 +106,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.OPERATOR_MANAGER);
 
         OperatorKey expectedOperator = new OperatorBuilder().build();
-        post(vertx, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=&operator_type=private", "", ar -> {
+        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=&operator_type=private", "", ar -> {
             try {
                 HttpResponse<Buffer> response = ar.result();
                 RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
@@ -130,7 +130,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.OPERATOR_MANAGER);
 
         OperatorKey expectedOperator = new OperatorBuilder().build();
-        post(vertx, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&operator_type=private", "", ar -> {
+        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&operator_type=private", "", ar -> {
             try {
                 HttpResponse<Buffer> response = ar.result();
                 RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
@@ -181,7 +181,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         OperatorKey expectedOperator = new OperatorBuilder()
                 .withType(OperatorType.PUBLIC)
                 .build();
-        post(vertx, "api/operator/update?name=test_operator&site_id=5&operator_type=public", "", ar -> {
+        post(vertx, testContext, "api/operator/update?name=test_operator&site_id=5&operator_type=public", "", ar -> {
             try {
                 HttpResponse<Buffer> response = ar.result();
                 OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);
@@ -215,7 +215,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         );
 
         OperatorKey expectedOperator = new OperatorBuilder().build();
-        post(vertx, "api/operator/update?name=test_operator&operator_type=private", "", ar -> {
+        post(vertx, testContext, "api/operator/update?name=test_operator&operator_type=private", "", ar -> {
             try {
                 HttpResponse<Buffer> response = ar.result();
                 OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);
@@ -241,7 +241,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         OperatorKey expectedOperator = new OperatorBuilder()
                 .withRoles(Role.OPTOUT, Role.OPERATOR)
                 .build();
-        post(vertx, "api/operator/roles?name=test_operator&roles=optout", "", ar -> {
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=optout", "", ar -> {
             try {
                 HttpResponse<Buffer> response = ar.result();
                 OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);

--- a/src/test/java/com/uid2/admin/vertx/OperatorKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/OperatorKeyServiceTest.java
@@ -49,21 +49,15 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
                 .withRoles(Role.OPTOUT, Role.OPERATOR)
                 .withType(OperatorType.PUBLIC)
                 .build();
-        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=optout&operator_type=public", "", ar -> {
-            try {
-                HttpResponse<Buffer> response = ar.result();
-                RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
+        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=optout&operator_type=public", "", response -> {
+            RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
 
-                assertAll(
-                        "operatorAdd",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertAddedOperatorKeyEquals(expectedOperator, revealedOperator.getAuthorizable()),
-                        () -> assertNotNull(revealedOperator.getPlaintextKey()),
-                        () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "operatorAdd",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertAddedOperatorKeyEquals(expectedOperator, revealedOperator.getAuthorizable()),
+                    () -> assertNotNull(revealedOperator.getPlaintextKey()),
+                    () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
             testContext.completeNow();
         });
     }
@@ -76,21 +70,15 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
                 .withRoles(Role.OPTOUT, Role.OPERATOR)
                 .withType(OperatorType.PUBLIC)
                 .build();
-        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=optout&operator_type=public", "", ar -> {
-            try {
-                HttpResponse<Buffer> response = ar.result();
-                RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
+        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=optout&operator_type=public", "", response -> {
+            RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
 
-                assertAll(
-                        "operatorAddUsesConfigPrefix",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertAddedOperatorKeyEquals(expectedOperator, revealedOperator.getAuthorizable()),
-                        () -> assertNotNull(revealedOperator.getPlaintextKey()),
-                        () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "operatorAddUsesConfigPrefix",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertAddedOperatorKeyEquals(expectedOperator, revealedOperator.getAuthorizable()),
+                    () -> assertNotNull(revealedOperator.getPlaintextKey()),
+                    () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
             testContext.completeNow();
         });
     }
@@ -106,21 +94,15 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.OPERATOR_MANAGER);
 
         OperatorKey expectedOperator = new OperatorBuilder().build();
-        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=&operator_type=private", "", ar -> {
-            try {
-                HttpResponse<Buffer> response = ar.result();
-                RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
+        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&roles=&operator_type=private", "", response -> {
+            RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
 
-                assertAll(
-                        "operatorKeyAddEmptyRole",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertAddedOperatorKeyEquals(expectedOperator, revealedOperator.getAuthorizable()),
-                        () -> assertNotNull(revealedOperator.getPlaintextKey()),
-                        () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "operatorKeyAddEmptyRole",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertAddedOperatorKeyEquals(expectedOperator, revealedOperator.getAuthorizable()),
+                    () -> assertNotNull(revealedOperator.getPlaintextKey()),
+                    () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
             testContext.completeNow();
         });
     }
@@ -130,21 +112,15 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.OPERATOR_MANAGER);
 
         OperatorKey expectedOperator = new OperatorBuilder().build();
-        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&operator_type=private", "", ar -> {
-            try {
-                HttpResponse<Buffer> response = ar.result();
-                RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
+        post(vertx, testContext, "api/operator/add?name=test_operator&protocol=trusted&site_id=5&operator_type=private", "", response -> {
+            RevealedKey<OperatorKey> revealedOperator = OBJECT_MAPPER.readValue(response.bodyAsString(), new TypeReference<>() {});
 
-                assertAll(
-                        "operatorKeyAddWithoutRole",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertAddedOperatorKeyEquals(expectedOperator, revealedOperator.getAuthorizable()),
-                        () -> assertNotNull(revealedOperator.getPlaintextKey()),
-                        () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "operatorKeyAddWithoutRole",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertAddedOperatorKeyEquals(expectedOperator, revealedOperator.getAuthorizable()),
+                    () -> assertNotNull(revealedOperator.getPlaintextKey()),
+                    () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
             testContext.completeNow();
         });
     }
@@ -181,20 +157,14 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         OperatorKey expectedOperator = new OperatorBuilder()
                 .withType(OperatorType.PUBLIC)
                 .build();
-        post(vertx, testContext, "api/operator/update?name=test_operator&site_id=5&operator_type=public", "", ar -> {
-            try {
-                HttpResponse<Buffer> response = ar.result();
-                OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);
+        post(vertx, testContext, "api/operator/update?name=test_operator&site_id=5&operator_type=public", "", response -> {
+            OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);
 
-                assertAll(
-                        "operatorUpdate",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertEquals(expectedOperator, operatorKey),
-                        () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "operatorUpdate",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertEquals(expectedOperator, operatorKey),
+                    () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
             testContext.completeNow();
         });
     }
@@ -215,20 +185,14 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         );
 
         OperatorKey expectedOperator = new OperatorBuilder().build();
-        post(vertx, testContext, "api/operator/update?name=test_operator&operator_type=private", "", ar -> {
-            try {
-                HttpResponse<Buffer> response = ar.result();
-                OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);
+        post(vertx, testContext, "api/operator/update?name=test_operator&operator_type=private", "", response -> {
+            OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);
 
-                assertAll(
-                        "operatorFlipPublicOperatorStatusViaUpdate",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertEquals(expectedOperator, operatorKey),
-                        () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "operatorFlipPublicOperatorStatusViaUpdate",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertEquals(expectedOperator, operatorKey),
+                    () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
             testContext.completeNow();
         });
     }
@@ -241,20 +205,14 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
         OperatorKey expectedOperator = new OperatorBuilder()
                 .withRoles(Role.OPTOUT, Role.OPERATOR)
                 .build();
-        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=optout", "", ar -> {
-            try {
-                HttpResponse<Buffer> response = ar.result();
-                OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=optout", "", response -> {
+            OperatorKey operatorKey = OBJECT_MAPPER.readValue(response.bodyAsString(), OperatorKey.class);
 
-                assertAll(
-                        "operatorKeySetRole",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(200, response.statusCode()),
-                        () -> assertEquals(expectedOperator, operatorKey),
-                        () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            assertAll(
+                    "operatorKeySetRole",
+                    () -> assertEquals(200, response.statusCode()),
+                    () -> assertEquals(expectedOperator, operatorKey),
+                    () -> verify(operatorKeyStoreWriter).upload(collectionOfSize(1)));
             testContext.completeNow();
         });
     }

--- a/src/test/java/com/uid2/admin/vertx/OperatorKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/OperatorKeyServiceTest.java
@@ -84,7 +84,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
     @Test
     public void operatorAddUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=4&roles=optout", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=4&roles=optout", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -126,25 +126,25 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
     @Test
     void operatorKeyAddInvalidRoleWithOperatorAndNonExistent(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,nonexistent", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,nonexistent", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void operatorKeyAddInvalidRoleCombinationWithOperatorAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout_service", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void operatorKeyAddInvalidRoleCombinationWithOptoutAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=optout,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=optout,optout_service", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void operatorKeyAddInvalidRoleCombinationWithOperatorAndOptoutAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
-        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout,optout_service", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
     public void operatorUpdateUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, testContext, "api/operator/update?name=test_client&site_id=4", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/operator/update?name=test_client&site_id=4", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
@@ -219,42 +219,42 @@ public class OperatorKeyServiceTest extends ServiceTestBase {
     public void operatorKeySetInvalidRoleCombinationWithOperatorAndNonexistent(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=operator,nonexistent", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=operator,nonexistent", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void operatorKeySetInvalidRoleCombinationWithOperatorAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/add?name=test_client&protocol=trusted&site_id=5&roles=operator,optout_service", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void operatorKeySetInvalidRoleCombinationWithOptoutAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=optout,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=optout,optout_service", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void operatorKeySetInvalidRoleCombinationWithOperatorptoutAndOptoutService(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=operator,optout,optout_service", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=operator,optout,optout_service", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void operatorKeySetEmptyRole(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator&roles=", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void operatorKeySetRoleWithoutRoleParam(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.OPERATOR_MANAGER);
         setOperatorKeys(new OperatorBuilder().build());
-        post(vertx, testContext, "api/operator/roles?name=test_operator", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/operator/roles?name=test_operator", "", expectHttpStatus(testContext, 400));
     }
 
     private static void assertAddedOperatorKeyEquals(OperatorKey expected, OperatorKey actual) {

--- a/src/test/java/com/uid2/admin/vertx/SaltServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SaltServiceTest.java
@@ -57,9 +57,7 @@ public class SaltServiceTest extends ServiceTestBase {
     void listSaltSnapshotsNoSnapshots(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.SECRET_MANAGER);
 
-        get(vertx, testContext, "api/salt/snapshots", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/salt/snapshots", response -> {
             assertEquals(200, response.statusCode());
             assertEquals(0, response.bodyAsJsonArray().size());
             testContext.completeNow();
@@ -77,9 +75,7 @@ public class SaltServiceTest extends ServiceTestBase {
         };
         setSnapshots(snapshots);
 
-        get(vertx, testContext, "api/salt/snapshots", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/salt/snapshots", response -> {
             assertEquals(200, response.statusCode());
             checkSnapshotsResponse(snapshots, response.bodyAsJsonArray().stream().toArray());
             testContext.completeNow();

--- a/src/test/java/com/uid2/admin/vertx/SaltServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SaltServiceTest.java
@@ -98,17 +98,11 @@ public class SaltServiceTest extends ServiceTestBase {
         };
         when(saltRotation.rotateSalts(any(), any(), eq(0.2))).thenReturn(ISaltRotation.Result.fromSnapshot(addedSnapshots[0]));
 
-        post(vertx, testContext, "api/salt/rotate?min_ages_in_seconds=50,60,70&fraction=0.2", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/salt/rotate?min_ages_in_seconds=50,60,70&fraction=0.2", "", response -> {
             assertEquals(200, response.statusCode());
             checkSnapshotsResponse(addedSnapshots, new Object[]{response.bodyAsJsonObject()});
-            try {
-                verify(saltStoreWriter).upload(any());
-                verify(saltStoreWriter, times(1)).archiveSaltLocations();
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(saltStoreWriter).upload(any());
+            verify(saltStoreWriter, times(1)).archiveSaltLocations();
             testContext.completeNow();
         });
     }
@@ -126,18 +120,12 @@ public class SaltServiceTest extends ServiceTestBase {
 
         when(saltRotation.rotateSalts(any(), any(), eq(0.2))).thenReturn(ISaltRotation.Result.noSnapshot("test"));
 
-        post(vertx, testContext, "api/salt/rotate?min_ages_in_seconds=50,60,70&fraction=0.2", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/salt/rotate?min_ages_in_seconds=50,60,70&fraction=0.2", "", response -> {
             assertEquals(200, response.statusCode());
             JsonObject jo = response.bodyAsJsonObject();
             assertFalse(jo.containsKey("effective"));
             assertFalse(jo.containsKey("expires"));
-            try {
-                verify(saltStoreWriter, times(0)).upload(any());
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(saltStoreWriter, times(0)).upload(any());
             testContext.completeNow();
         });
     }

--- a/src/test/java/com/uid2/admin/vertx/SaltServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SaltServiceTest.java
@@ -57,7 +57,7 @@ public class SaltServiceTest extends ServiceTestBase {
     void listSaltSnapshotsNoSnapshots(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.SECRET_MANAGER);
 
-        get(vertx, "api/salt/snapshots", ar -> {
+        get(vertx, testContext, "api/salt/snapshots", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -77,7 +77,7 @@ public class SaltServiceTest extends ServiceTestBase {
         };
         setSnapshots(snapshots);
 
-        get(vertx, "api/salt/snapshots", ar -> {
+        get(vertx, testContext, "api/salt/snapshots", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -102,7 +102,7 @@ public class SaltServiceTest extends ServiceTestBase {
         };
         when(saltRotation.rotateSalts(any(), any(), eq(0.2))).thenReturn(ISaltRotation.Result.fromSnapshot(addedSnapshots[0]));
 
-        post(vertx, "api/salt/rotate?min_ages_in_seconds=50,60,70&fraction=0.2", "", ar -> {
+        post(vertx, testContext, "api/salt/rotate?min_ages_in_seconds=50,60,70&fraction=0.2", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -130,7 +130,7 @@ public class SaltServiceTest extends ServiceTestBase {
 
         when(saltRotation.rotateSalts(any(), any(), eq(0.2))).thenReturn(ISaltRotation.Result.noSnapshot("test"));
 
-        post(vertx, "api/salt/rotate?min_ages_in_seconds=50,60,70&fraction=0.2", "", ar -> {
+        post(vertx, testContext, "api/salt/rotate?min_ages_in_seconds=50,60,70&fraction=0.2", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());

--- a/src/test/java/com/uid2/admin/vertx/SearchServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SearchServiceTest.java
@@ -12,10 +12,8 @@ import com.uid2.shared.secret.KeyHashResult;
 import com.uid2.shared.secret.KeyHasher;
 import com.uid2.shared.util.Mapper;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,7 +46,7 @@ public class SearchServiceTest extends ServiceTestBase {
     @EnumSource(value = Role.class, names = {"ADMINISTRATOR"}, mode = EnumSource.Mode.EXCLUDE)
     void searchAsNonAdminFails(Role role, Vertx vertx, VertxTestContext testContext) {
         fakeAuth(role);
-        post(vertx, testContext, searchUrl, "1234567", expectHttpError(testContext, 401));
+        post(vertx, testContext, searchUrl, "1234567", expectHttpStatus(testContext, 401));
     }
 
     @Test
@@ -62,7 +60,7 @@ public class SearchServiceTest extends ServiceTestBase {
 
     @Test
     void searchWithoutRoleFails(Vertx vertx, VertxTestContext testContext) {
-        post(vertx, testContext, searchUrl, "1234567", expectHttpError(testContext, 401));
+        post(vertx, testContext, searchUrl, "1234567", expectHttpStatus(testContext, 401));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/uid2/admin/vertx/SearchServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SearchServiceTest.java
@@ -54,7 +54,7 @@ public class SearchServiceTest extends ServiceTestBase {
     @Test
     void searchAsAdminPasses(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
-        post(vertx, searchUrl, "123456", response -> {
+        post(vertx, testContext, searchUrl, "123456", response -> {
             assertAll(
                     "searchAsAdminPasses",
                     () -> assertTrue(response.succeeded()),

--- a/src/test/java/com/uid2/admin/vertx/SearchServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SearchServiceTest.java
@@ -55,11 +55,7 @@ public class SearchServiceTest extends ServiceTestBase {
     void searchAsAdminPasses(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
         post(vertx, testContext, searchUrl, "123456", response -> {
-            assertAll(
-                    "searchAsAdminPasses",
-                    () -> assertTrue(response.succeeded()),
-                    () -> assertEquals(200, response.result().statusCode())
-            );
+            assertEquals(200, response.statusCode());
             testContext.completeNow();
         });
     }
@@ -74,17 +70,13 @@ public class SearchServiceTest extends ServiceTestBase {
     void searchWithShortQueryStringReturns400Error(String parameter, Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
         post(vertx, "api/search", parameter, response -> {
-            try {
-                assertAll(
-                        "searchWithShortQueryStringReturns400Error",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(400, response.result().statusCode()),
-                        () -> assertEquals("{\"message\":\"Parameter too short. Must be 6 or more characters.\",\"status\":\"error\"}", response.result().bodyAsString())
-                );
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
+            assertAll(
+                    "searchWithShortQueryStringReturns400Error",
+                    () -> assertTrue(response.succeeded()),
+                    () -> assertEquals(400, response.result().statusCode()),
+                    () -> assertEquals("{\"message\":\"Parameter too short. Must be 6 or more characters.\",\"status\":\"error\"}", response.result().bodyAsString())
+            );
+            testContext.completeNow();
         });
     }
 
@@ -98,25 +90,21 @@ public class SearchServiceTest extends ServiceTestBase {
         setAdminUsers(adminUsers);
 
         post(vertx, searchUrl, searchString, response -> {
-            try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
-                JsonArray foundClientKeys = result.getJsonArray("ClientKeys");
-                JsonArray foundOperatorKeys = result.getJsonArray("OperatorKeys");
-                JsonArray foundAdminKeys = result.getJsonArray("AdministratorKeys");
+            HttpResponse<Buffer> httpResponse = response.result();
+            JsonObject result = httpResponse.bodyAsJsonObject();
+            JsonArray foundClientKeys = result.getJsonArray("ClientKeys");
+            JsonArray foundOperatorKeys = result.getJsonArray("OperatorKeys");
+            JsonArray foundAdminKeys = result.getJsonArray("AdministratorKeys");
 
-                assertAll(
-                        "searchByClientKeyNotFound",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(0, foundClientKeys.size()),
-                        () -> assertEquals(0, foundOperatorKeys.size()),
-                        () -> assertEquals(0, foundAdminKeys.size())
-                );
+            assertAll(
+                    "searchByClientKeyNotFound",
+                    () -> assertTrue(response.succeeded()),
+                    () -> assertEquals(0, foundClientKeys.size()),
+                    () -> assertEquals(0, foundOperatorKeys.size()),
+                    () -> assertEquals(0, foundAdminKeys.size())
+            );
 
-                testContext.completeNow();
-            } catch (Throwable ex) {
-                testContext.failNow(ex);
-            }
+            testContext.completeNow();
         });
     }
 
@@ -140,23 +128,17 @@ public class SearchServiceTest extends ServiceTestBase {
         setClientKeys(clientKeys);
         String expectedPlaintextClientKey = "UID2-C-L-999-fCXrMM.fsR3mDqAXELtWWMS+xG1s7RdgRTMqdOH2qaAo=";
         ClientKey expectedClientKey = clientKeys.get(expectedPlaintextClientKey);
-        post(vertx, searchUrl, expectedPlaintextClientKey, response -> {
-            try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
-                JsonArray foundKeys = result.getJsonArray("ClientKeys");
-                ClientKey clientKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), ClientKey.class);
+        post(vertx, testContext, searchUrl, expectedPlaintextClientKey, response -> {
+            JsonObject result = response.bodyAsJsonObject();
+            JsonArray foundKeys = result.getJsonArray("ClientKeys");
+            ClientKey clientKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), ClientKey.class);
 
-                assertAll(
-                        "searchClientKeyFindsKey",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(1, foundKeys.size()),
-                        () -> assertEquals(expectedClientKey, clientKey)
-                );
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
+            assertAll(
+                    "searchClientKeyFindsKey",
+                    () -> assertEquals(1, foundKeys.size()),
+                    () -> assertEquals(expectedClientKey, clientKey)
+            );
+            testContext.completeNow();
         });
     }
 
@@ -168,23 +150,17 @@ public class SearchServiceTest extends ServiceTestBase {
         setClientKeys(clientKeys);
         String expectedPlaintextClientKey = "UID2-C-L-999-fCXrMM.fsR3mDqAXELtWWMS+xG1s7RdgRTMqdOH2qaAo=";
         ClientKey expectedClientKey = clientKeys.get(expectedPlaintextClientKey);
-        post(vertx, searchUrl, expectedClientKey.getKeyHash(), response -> {
-            try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
-                JsonArray foundKeys = result.getJsonArray("ClientKeys");
-                ClientKey clientKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), ClientKey.class);
+        post(vertx, testContext, searchUrl, expectedClientKey.getKeyHash(), response -> {
+            JsonObject result = response.bodyAsJsonObject();
+            JsonArray foundKeys = result.getJsonArray("ClientKeys");
+            ClientKey clientKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), ClientKey.class);
 
-                assertAll(
-                        "searchClientKeyByHashFindsKey",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(1, foundKeys.size()),
-                        () -> assertEquals(expectedClientKey, clientKey)
-                );
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
+            assertAll(
+                    "searchClientKeyByHashFindsKey",
+                    () -> assertEquals(1, foundKeys.size()),
+                    () -> assertEquals(expectedClientKey, clientKey)
+            );
+            testContext.completeNow();
         });
     }
 
@@ -196,23 +172,17 @@ public class SearchServiceTest extends ServiceTestBase {
         setOperatorKeys(operatorKeys);
         String expectedPlaintextOperatorKey = "UID2-O-L-999-dp9Dt0.JVoGpynN4J8nMA7FxmzsavxJa8B9H74y9xdEE=";
         OperatorKey expectedOperatorKey = operatorKeys.get(expectedPlaintextOperatorKey);
-        post(vertx, searchUrl, expectedPlaintextOperatorKey, response -> {
-            try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
-                JsonArray foundKeys = result.getJsonArray("OperatorKeys");
-                OperatorKey operatorKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), OperatorKey.class);
+        post(vertx, testContext, searchUrl, expectedPlaintextOperatorKey, response -> {
+            JsonObject result = response.bodyAsJsonObject();
+            JsonArray foundKeys = result.getJsonArray("OperatorKeys");
+            OperatorKey operatorKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), OperatorKey.class);
 
-                assertAll(
-                        "searchOperatorKeyFindsKey",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(1, foundKeys.size()),
-                        () -> assertEquals(expectedOperatorKey, operatorKey)
-                );
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
+            assertAll(
+                    "searchOperatorKeyFindsKey",
+                    () -> assertEquals(1, foundKeys.size()),
+                    () -> assertEquals(expectedOperatorKey, operatorKey)
+            );
+            testContext.completeNow();
         });
     }
 
@@ -224,23 +194,17 @@ public class SearchServiceTest extends ServiceTestBase {
         setOperatorKeys(operatorKeys);
         String expectedPlaintextOperatorKey = "UID2-O-L-999-dp9Dt0.JVoGpynN4J8nMA7FxmzsavxJa8B9H74y9xdEE=";
         OperatorKey expectedOperatorKey = operatorKeys.get(expectedPlaintextOperatorKey);
-        post(vertx, searchUrl, expectedOperatorKey.getKeyHash(), response -> {
-            try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
-                JsonArray foundKeys = result.getJsonArray("OperatorKeys");
-                OperatorKey operatorKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), OperatorKey.class);
+        post(vertx, testContext, searchUrl, expectedOperatorKey.getKeyHash(), response -> {
+            JsonObject result = response.bodyAsJsonObject();
+            JsonArray foundKeys = result.getJsonArray("OperatorKeys");
+            OperatorKey operatorKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), OperatorKey.class);
 
-                assertAll(
-                        "searchOperatorKeyByHashFindsKey",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(1, foundKeys.size()),
-                        () -> assertEquals(expectedOperatorKey, operatorKey)
-                );
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
+            assertAll(
+                    "searchOperatorKeyByHashFindsKey",
+                    () -> assertEquals(1, foundKeys.size()),
+                    () -> assertEquals(expectedOperatorKey, operatorKey)
+            );
+            testContext.completeNow();
         });
     }
 
@@ -250,23 +214,17 @@ public class SearchServiceTest extends ServiceTestBase {
         AdminUser[] adminUsers = getAdminUsers();
 
         setAdminUsers(adminUsers);
-        post(vertx, searchUrl, "UID2-A-L-WYHV5i.Se6uQDk/N1KsKk4T8CWAFSU5oyObkCes9yFG8=", response -> {
-            try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
-                JsonArray foundKeys = result.getJsonArray("AdministratorKeys");
-                JsonObject adminUser = foundKeys.getJsonObject(0);
+        post(vertx, testContext, searchUrl, "UID2-A-L-WYHV5i.Se6uQDk/N1KsKk4T8CWAFSU5oyObkCes9yFG8=", response -> {
+            JsonObject result = response.bodyAsJsonObject();
+            JsonArray foundKeys = result.getJsonArray("AdministratorKeys");
+            JsonObject adminUser = foundKeys.getJsonObject(0);
 
-                assertAll(
-                        "searchAdminUserFindsKey",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(1, foundKeys.size()),
-                        () -> assertAdminUser(adminUsers[0], adminUser)
-                );
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
+            assertAll(
+                    "searchAdminUserFindsKey",
+                    () -> assertEquals(1, foundKeys.size()),
+                    () -> assertAdminUser(adminUsers[0], adminUser)
+            );
+            testContext.completeNow();
         });
     }
 
@@ -276,23 +234,17 @@ public class SearchServiceTest extends ServiceTestBase {
         AdminUser[] adminUsers = getAdminUsers();
 
         setAdminUsers(adminUsers);
-        post(vertx, searchUrl, adminUsers[0].getKeyHash(), response -> {
-            try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
-                JsonArray foundKeys = result.getJsonArray("AdministratorKeys");
-                JsonObject adminUser = foundKeys.getJsonObject(0);
+        post(vertx, testContext, searchUrl, adminUsers[0].getKeyHash(), response -> {
+            JsonObject result = response.bodyAsJsonObject();
+            JsonArray foundKeys = result.getJsonArray("AdministratorKeys");
+            JsonObject adminUser = foundKeys.getJsonObject(0);
 
-                assertAll(
-                        "searchAdminUserByHashFindsKey",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(1, foundKeys.size()),
-                        () -> assertAdminUser(adminUsers[0], adminUser)
-                );
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
+            assertAll(
+                    "searchAdminUserByHashFindsKey",
+                    () -> assertEquals(1, foundKeys.size()),
+                    () -> assertAdminUser(adminUsers[0], adminUser)
+            );
+            testContext.completeNow();
         });
     }
 
@@ -310,23 +262,17 @@ public class SearchServiceTest extends ServiceTestBase {
                 .filter(c -> expectedSecret.equals(c.getSecret()))
                 .collect(Collectors.toList())
                 .get(0);
-        post(vertx, searchUrl, searchString, response -> {
-            try {
-                HttpResponse<Buffer> httpResponse = response.result();
-                JsonObject result = httpResponse.bodyAsJsonObject();
-                JsonArray foundKeys = result.getJsonArray("ClientKeys");
-                ClientKey clientKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), ClientKey.class);
+        post(vertx, testContext, searchUrl, searchString, response -> {
+            JsonObject result = response.bodyAsJsonObject();
+            JsonArray foundKeys = result.getJsonArray("ClientKeys");
+            ClientKey clientKey = OBJECT_MAPPER.readValue(foundKeys.getJsonObject(0).toString(), ClientKey.class);
 
-                assertAll(
-                        "searchByClientSecretSuccess",
-                        () -> assertTrue(response.succeeded()),
-                        () -> assertEquals(1, foundKeys.size()),
-                        () -> assertEquals(expectedClientKey, clientKey)
-                );
-                testContext.completeNow();
-            } catch (Throwable ex) {
-                testContext.failNow(ex);
-            }
+            assertAll(
+                    "searchByClientSecretSuccess",
+                    () -> assertEquals(1, foundKeys.size()),
+                    () -> assertEquals(expectedClientKey, clientKey)
+            );
+            testContext.completeNow();
         });
     }
 

--- a/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
@@ -89,14 +89,15 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
     @Test
     void addLinkMissingPayload(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
-
-        postWithoutBody(vertx, "api/service_link/add", testContext.succeeding(response -> testContext.verify(() -> {
-            assertEquals(400, response.statusCode());
-            assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
-            verify(serviceStoreWriter, never()).upload(null, null);
-            verify(serviceLinkStoreWriter, never()).upload(null, null);
-            testContext.completeNow();
-        })));
+        postWithoutBody(vertx, "api/service_link/add")
+                .onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+                            assertEquals(400, response.statusCode());
+                            assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
+                            verify(serviceStoreWriter, never()).upload(null, null);
+                            verify(serviceLinkStoreWriter, never()).upload(null, null);
+                            testContext.completeNow();
+                        }
+                )));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
@@ -54,14 +54,14 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
     void listLinksNoLinks(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 
-        get(vertx, "api/service_link/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext,  "api/service_link/list", response -> {
             assertEquals(200, response.statusCode());
             JsonArray respArray = response.bodyAsJsonArray();
             assertEquals(0, respArray.size());
             verify(serviceStoreWriter, never()).upload(null, null);
             verify(serviceLinkStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -77,13 +77,13 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
 
         setServiceLinks(expectedServiceLinks);
 
-        get(vertx, "api/service_link/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/service_link/list", response -> {
             assertEquals(200, response.statusCode());
             checkServiceLinkResponse(expectedServiceLinks, response.bodyAsJsonArray());
             verify(serviceStoreWriter, never()).upload(null, null);
             verify(serviceLinkStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -116,7 +116,7 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
         post(vertx, "api/service_link/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(400, response.statusCode());
             assertEquals("required parameters: link_id, service_id, site_id, name", response.bodyAsJsonObject().getString("message"));
-            verify(serviceStoreWriter, never()).upload(null, null);
+            verifyNoInteractions(serviceStoreWriter);
             verify(serviceLinkStoreWriter, never()).upload(null, null);
             testContext.completeNow();
         })));

--- a/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
@@ -89,15 +89,14 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
     @Test
     void addLinkMissingPayload(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
-        postWithoutBody(vertx, "api/service_link/add")
-                .onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        postWithoutBody(vertx, testContext, "api/service_link/add", response -> {
                             assertEquals(400, response.statusCode());
                             assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
                             verify(serviceStoreWriter, never()).upload(null, null);
                             verify(serviceLinkStoreWriter, never()).upload(null, null);
                             testContext.completeNow();
                         }
-                )));
+                );
     }
 
     @ParameterizedTest

--- a/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
@@ -54,7 +54,7 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
     void listLinksNoLinks(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 
-        get(vertx, "api/service_link/list", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/service_link/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.statusCode());
             JsonArray respArray = response.bodyAsJsonArray();
             assertEquals(0, respArray.size());
@@ -77,7 +77,7 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
 
         setServiceLinks(expectedServiceLinks);
 
-        get(vertx, "api/service_link/list", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/service_link/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.statusCode());
             checkServiceLinkResponse(expectedServiceLinks, response.bodyAsJsonArray());
             verify(serviceStoreWriter, never()).upload(null, null);

--- a/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceLinkServiceTest.java
@@ -112,13 +112,13 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
 
         jo.remove(parameter);
 
-        post(vertx, "api/service_link/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service_link/add", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("required parameters: link_id, service_id, site_id, name", response.bodyAsJsonObject().getString("message"));
             verifyNoInteractions(serviceStoreWriter);
             verify(serviceLinkStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -131,13 +131,13 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
         jo.put("site_id", 124);
         jo.put("name", "name1");
 
-        post(vertx, "api/service_link/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service_link/add", jo.encode(), response -> {
             assertEquals(404, response.statusCode());
             assertEquals("service_id 1 not valid", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             verify(serviceLinkStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -152,13 +152,13 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
         jo.put("site_id", 124);
         jo.put("name", "name1");
 
-        post(vertx, "api/service_link/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service_link/add", jo.encode(), response -> {
             assertEquals(404, response.statusCode());
             assertEquals("site_id 124 not valid", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             verify(serviceLinkStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -175,13 +175,13 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
         jo.put("site_id", 123);
         jo.put("name", "name1");
 
-        post(vertx, "api/service_link/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service_link/add", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("service link already exists", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             verify(serviceLinkStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -199,13 +199,13 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
         jo.put("site_id", 123);
         jo.put("name", "name1");
 
-        post(vertx, "api/service_link/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service_link/add", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             checkServiceLinkJson(expected, response.bodyAsJsonObject());
             verify(serviceStoreWriter, never()).upload(null, null);
             verify(serviceLinkStoreWriter, times(1)).upload(List.of(expected), null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -225,12 +225,12 @@ public class ServiceLinkServiceTest extends ServiceTestBase {
         jo.put("site_id", 123);
         jo.put("name", "name1");
 
-        post(vertx, "api/service_link/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service_link/add", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             checkServiceLinkJson(expected, response.bodyAsJsonObject());
             verify(serviceStoreWriter, never()).upload(null, null);
             verify(serviceLinkStoreWriter, times(1)).upload(List.of(existingLink, expected), null);
             testContext.completeNow();
-        })));
+        });
     }
 }

--- a/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
@@ -64,13 +64,13 @@ public class ServiceServiceTest extends ServiceTestBase {
     void listServicesNoServices(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 
-        get(vertx, "api/service/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/service/list", response -> {
             assertEquals(200, response.statusCode());
             JsonArray respArray = response.bodyAsJsonArray();
             assertEquals(0, respArray.size());
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -86,12 +86,12 @@ public class ServiceServiceTest extends ServiceTestBase {
 
         setServices(expectedServices);
 
-        get(vertx, "api/service/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/service/list", response -> {
             assertEquals(200, response.statusCode());
             checkServiceResponse(expectedServices, response.bodyAsJsonArray());
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -101,12 +101,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         Service existingService = new Service(3, 124, "name1", Set.of(Role.GENERATOR, Role.SHARING_PORTAL));
         setServices(existingService);
 
-        get(vertx, "api/service/list/asdf").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/service/list/asdf", response -> {
             assertEquals(400, response.statusCode());
             assertEquals("failed to parse a service_id from request", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -116,12 +116,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         Service existingService = new Service(1, 124, "name1", Set.of(Role.GENERATOR, Role.SHARING_PORTAL));
         setServices(existingService);
 
-        get(vertx, "api/service/list/3").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/service/list/3", response -> {
             assertEquals(404, response.statusCode());
             assertEquals("failed to find a service for service_id: 3", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -131,12 +131,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         Service existingService = new Service(3, 124, "name1", Set.of(Role.GENERATOR, Role.SHARING_PORTAL));
         setServices(existingService);
 
-        get(vertx, "api/service/list/3").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, testContext, "api/service/list/3", response -> {
             assertEquals(200, response.statusCode());
             checkServiceJson(existingService, response.bodyAsJsonObject());
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
@@ -143,13 +143,12 @@ public class ServiceServiceTest extends ServiceTestBase {
     void addServiceMissingPayload(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 
-        postWithoutBody(vertx, "api/service/add")
-                .onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        postWithoutBody(vertx, testContext, "api/service/add", response -> {
                     assertEquals(400, response.statusCode());
                     assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
                     verify(serviceStoreWriter, never()).upload(null, null);
                     testContext.completeNow();
-                })));
+                });
     }
 
     @ParameterizedTest
@@ -325,13 +324,12 @@ public class ServiceServiceTest extends ServiceTestBase {
     void updateRolesMissingPayload(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 
-        postWithoutBody(vertx, "api/service/roles")
-            .onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+        postWithoutBody(vertx, testContext, "api/service/roles", response -> {
                 assertEquals(400, response.statusCode());
                 assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
                 verify(serviceStoreWriter, never()).upload(null, null);
                 testContext.completeNow();
-            })));
+            });
     }
 
     @ParameterizedTest

--- a/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
@@ -64,7 +64,7 @@ public class ServiceServiceTest extends ServiceTestBase {
     void listServicesNoServices(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 
-        get(vertx, "api/service/list", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/service/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.statusCode());
             JsonArray respArray = response.bodyAsJsonArray();
             assertEquals(0, respArray.size());
@@ -86,7 +86,7 @@ public class ServiceServiceTest extends ServiceTestBase {
 
         setServices(expectedServices);
 
-        get(vertx, "api/service/list", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/service/list").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.statusCode());
             checkServiceResponse(expectedServices, response.bodyAsJsonArray());
             verify(serviceStoreWriter, never()).upload(null, null);
@@ -101,7 +101,7 @@ public class ServiceServiceTest extends ServiceTestBase {
         Service existingService = new Service(3, 124, "name1", Set.of(Role.GENERATOR, Role.SHARING_PORTAL));
         setServices(existingService);
 
-        get(vertx, "api/service/list/asdf", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/service/list/asdf").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(400, response.statusCode());
             assertEquals("failed to parse a service_id from request", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
@@ -116,7 +116,7 @@ public class ServiceServiceTest extends ServiceTestBase {
         Service existingService = new Service(1, 124, "name1", Set.of(Role.GENERATOR, Role.SHARING_PORTAL));
         setServices(existingService);
 
-        get(vertx, "api/service/list/3", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/service/list/3").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(404, response.statusCode());
             assertEquals("failed to find a service for service_id: 3", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
@@ -131,7 +131,7 @@ public class ServiceServiceTest extends ServiceTestBase {
         Service existingService = new Service(3, 124, "name1", Set.of(Role.GENERATOR, Role.SHARING_PORTAL));
         setServices(existingService);
 
-        get(vertx, "api/service/list/3", testContext.succeeding(response -> testContext.verify(() -> {
+        get(vertx, "api/service/list/3").onComplete(testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.statusCode());
             checkServiceJson(existingService, response.bodyAsJsonObject());
             verify(serviceStoreWriter, never()).upload(null, null);

--- a/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
@@ -163,12 +163,12 @@ public class ServiceServiceTest extends ServiceTestBase {
 
         jo.remove(parameter);
 
-        post(vertx, "api/service/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/add", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("required parameters: site_id, name, roles", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -180,12 +180,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("name", "name1");
         jo.put("roles", new JsonArray());
 
-        post(vertx, "api/service/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/add", jo.encode(), response -> {
             assertEquals(404, response.statusCode());
             assertEquals("site_id 123 not valid", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -199,12 +199,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("name", "");
         jo.put("roles", new JsonArray());
 
-        post(vertx, "api/service/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/add", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("name cannot be empty", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -219,12 +219,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("name", "testName1");
         jo.put("roles", new JsonArray());
 
-        post(vertx, "api/service/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/add", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("site_id 123 already has service of name testName1", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -241,12 +241,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("name", "name1");
         jo.put("roles", ja);
 
-        post(vertx, "api/service/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/add", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("invalid parameter: roles", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -260,13 +260,13 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("name", "name1");
         jo.put("roles", new JsonArray());
 
-        post(vertx, "api/service/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/add", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             Service expectedService = new Service(1, 123, "name1", Set.of());
             checkServiceJson(expectedService, response.bodyAsJsonObject());
             verify(serviceStoreWriter, times(1)).upload(List.of(expectedService), null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -284,13 +284,13 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("name", "name1");
         jo.put("roles", ja);
 
-        post(vertx, "api/service/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/add", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             Service expectedService = new Service(1, 123, "name1", Set.of(Role.GENERATOR, Role.ID_READER));
             checkServiceJson(expectedService, response.bodyAsJsonObject());
             verify(serviceStoreWriter, times(1)).upload(List.of(expectedService), null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -311,13 +311,13 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("name", "name2");
         jo.put("roles", ja);
 
-        post(vertx, "api/service/add", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/add", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             Service expectedService = new Service(2, 123, "name2", Set.of(Role.GENERATOR, Role.ID_READER));
             checkServiceJson(expectedService, response.bodyAsJsonObject());
             verify(serviceStoreWriter, times(1)).upload(List.of(existingService, expectedService), null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -343,12 +343,12 @@ public class ServiceServiceTest extends ServiceTestBase {
 
         jo.remove(parameter);
 
-        post(vertx, "api/service/roles", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/roles", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("required parameters: service_id, roles", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -364,12 +364,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("service_id", 2);
         jo.put("roles", ja);
 
-        post(vertx, "api/service/roles", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/roles", jo.encode(), response -> {
             assertEquals(404, response.statusCode());
             assertEquals("failed to find a service for service_id: 2", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -385,12 +385,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("service_id", 1);
         jo.put("roles", ja);
 
-        post(vertx, "api/service/roles", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/roles", jo.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("invalid parameter: roles", response.bodyAsJsonObject().getString("message"));
             verify(serviceStoreWriter, never()).upload(null, null);
             testContext.completeNow();
-        })));
+        });
     }
 
     @Test
@@ -408,12 +408,12 @@ public class ServiceServiceTest extends ServiceTestBase {
         jo.put("service_id", 1);
         jo.put("roles", ja);
 
-        post(vertx, "api/service/roles", jo.encode(), testContext.succeeding(response -> testContext.verify(() -> {
+        post(vertx, testContext, "api/service/roles", jo.encode(), response -> {
             assertEquals(200, response.statusCode());
             existingService.setRoles(Set.of(Role.GENERATOR, Role.ADMINISTRATOR));
             checkServiceJson(existingService, response.bodyAsJsonObject());
             verify(serviceStoreWriter, times(1)).upload(List.of(existingService), null);
             testContext.completeNow();
-        })));
+        });
     }
 }

--- a/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ServiceServiceTest.java
@@ -143,12 +143,13 @@ public class ServiceServiceTest extends ServiceTestBase {
     void addServiceMissingPayload(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 
-        postWithoutBody(vertx, "api/service/add", testContext.succeeding(response -> testContext.verify(() -> {
-            assertEquals(400, response.statusCode());
-            assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
-            verify(serviceStoreWriter, never()).upload(null, null);
-            testContext.completeNow();
-        })));
+        postWithoutBody(vertx, "api/service/add")
+                .onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+                    assertEquals(400, response.statusCode());
+                    assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
+                    verify(serviceStoreWriter, never()).upload(null, null);
+                    testContext.completeNow();
+                })));
     }
 
     @ParameterizedTest
@@ -324,12 +325,13 @@ public class ServiceServiceTest extends ServiceTestBase {
     void updateRolesMissingPayload(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 
-        postWithoutBody(vertx, "api/service/roles", testContext.succeeding(response -> testContext.verify(() -> {
-            assertEquals(400, response.statusCode());
-            assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
-            verify(serviceStoreWriter, never()).upload(null, null);
-            testContext.completeNow();
-        })));
+        postWithoutBody(vertx, "api/service/roles")
+            .onComplete(testContext.succeeding(response -> testContext.verify(() -> {
+                assertEquals(400, response.statusCode());
+                assertEquals("json payload required but not provided", response.bodyAsJsonObject().getString("message"));
+                verify(serviceStoreWriter, never()).upload(null, null);
+                testContext.completeNow();
+            })));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
@@ -107,7 +107,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, "api/sharing/list/42", ar -> {
+        get(vertx, testContext, "api/sharing/list/42", ar -> {
             HttpResponse response = ar.result();
             assertEquals(404, response.statusCode());
 
@@ -176,7 +176,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": " + keysets.get(3).hashCode() + "\n" +
                 "  }";
 
-        post(vertx, "api/sharing/list/5", body, ar -> {
+        post(vertx, testContext, "api/sharing/list/5", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -213,7 +213,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": 0\n" +
                 "  }";
 
-        post(vertx, "api/sharing/list/8", body, ar -> {
+        post(vertx, testContext, "api/sharing/list/8", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -259,7 +259,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": 0\n" +
                 "  }";
 
-        post(vertx, "api/sharing/list/8", body, ar -> {
+        post(vertx, testContext, "api/sharing/list/8", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -302,7 +302,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": 0\n" +
                 "  }";
 
-        post(vertx, "api/sharing/list/-1", body, ar -> {
+        post(vertx, testContext, "api/sharing/list/-1", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -372,7 +372,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, "api/sharing/lists", ar -> {
+        get(vertx, testContext, "api/sharing/lists", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -404,7 +404,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, "api/sharing/keyset/1", ar -> {
+        get(vertx, testContext, "api/sharing/keyset/1", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -426,7 +426,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, "api/sharing/keyset/1", ar -> {
+        get(vertx, testContext, "api/sharing/keyset/1", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(404, response.statusCode());
@@ -447,7 +447,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, "api/sharing/keysets", ar -> {
+        get(vertx, testContext, "api/sharing/keysets", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -486,7 +486,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -519,7 +519,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -553,7 +553,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -592,7 +592,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"keyset_id\": 3" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -642,7 +642,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"keyset_id\": 1" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -679,7 +679,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -716,7 +716,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -749,7 +749,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -785,7 +785,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -818,7 +818,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"TEST\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -850,7 +850,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -881,7 +881,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -912,7 +912,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"keyset_id\": 1" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -944,7 +944,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -973,7 +973,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -1002,7 +1002,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -1030,7 +1030,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -1058,7 +1058,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -1087,7 +1087,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -1118,7 +1118,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -1148,7 +1148,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"site_id\": 5" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
@@ -1174,7 +1174,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"site_id\": 3" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -1203,7 +1203,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"allowed_sites\": null" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -1231,7 +1231,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"keyset_id\": 1" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -1260,7 +1260,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"allowed_sites\": null" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -1298,7 +1298,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"site_id\": 8" +
                 "  }";
 
-        post(vertx, "api/sharing/keyset", body, ar -> {
+        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());

--- a/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
@@ -124,9 +124,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": " + keysets.get(3).hashCode() + "\n" +
                 "  }";
 
-        post(vertx, "api/sharing/list/5", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/list/5", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(3, 5, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -162,9 +160,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": " + keysets.get(3).hashCode() + "\n" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/list/5", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/list/5", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(3, 5, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, Set.of(ClientType.DSP, ClientType.ADVERTISER));
@@ -199,9 +195,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": 0\n" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/list/8", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/list/8", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(6, 8, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -210,11 +204,7 @@ public class SharingServiceTest extends ServiceTestBase {
             assertEquals(expected.getAllowedSites(), keysets.get(6).getAllowedSites());
 
             //Ensure new key was created
-            try {
-                verify(keysetKeyManager).addKeysetKey(6);
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keysetKeyManager).addKeysetKey(6);
             testContext.completeNow();
         });
     }
@@ -245,9 +235,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": 0\n" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/list/8", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/list/8", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(6, 8, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, Set.of(ClientType.DSP, ClientType.ADVERTISER));
@@ -258,11 +246,7 @@ public class SharingServiceTest extends ServiceTestBase {
             assertEquals(expected.getAllowedTypes(), keysets.get(6).getAllowedTypes());
 
             //Ensure new key was created
-            try {
-                verify(keysetKeyManager).addKeysetKey(6);
-            } catch (Exception ex) {
-                fail(ex);
-            }
+            verify(keysetKeyManager).addKeysetKey(6);
             testContext.completeNow();
         });
     }
@@ -288,9 +272,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": 0\n" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/list/-1", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/list/-1", body, response -> {
             assertEquals(400, response.statusCode());
             testContext.completeNow();
         });
@@ -326,9 +308,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"hash\": " + keysets.get(3).hashCode() + "\n" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/list/5", body1, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/list/5", body1, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(3, 5, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -336,9 +316,7 @@ public class SharingServiceTest extends ServiceTestBase {
 
             assertEquals(expected.getAllowedSites(), keysets.get(3).getAllowedSites());
 
-            post(vertx, testContext, "api/sharing/list/5", body2, ar2 -> {
-                assertTrue(ar2.succeeded());
-                HttpResponse response2 = ar2.result();
+            post(vertx, testContext, "api/sharing/list/5", body2, response2 -> {
                 assertEquals(409, response2.statusCode());
 
                 testContext.completeNow();
@@ -462,9 +440,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("You must specify exactly one of: keyset_id, site_id", response.bodyAsJsonObject().getString("message"));
 
@@ -495,9 +471,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("You must specify exactly one of: keyset_id, site_id", response.bodyAsJsonObject().getString("message"));
 
@@ -529,9 +503,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(1, 5, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -568,9 +540,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"keyset_id\": 3" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(3, 5, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, Set.of(ClientType.DSP, ClientType.ADVERTISER));
@@ -618,9 +588,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"keyset_id\": 1" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(1, 5, "test-name", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -655,9 +623,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(4, 8, "test-name", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -692,9 +658,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Site id 5 not valid", response.bodyAsJsonObject().getString("message"));
 
@@ -725,9 +689,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Site id 25 not valid", response.bodyAsJsonObject().getString("message"));
 
@@ -761,9 +723,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "     \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             testContext.completeNow();
@@ -794,9 +754,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"TEST\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("AdminKeyset with same site_id and name already exists", response.bodyAsJsonObject().getString("message"));
 
@@ -826,9 +784,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(4, 8, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -857,9 +813,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(4, 8, "test", Set.of(), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -888,9 +842,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"keyset_id\": 1" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(1, 5, "test", Set.of(), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -920,9 +872,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Site id " + input + " not valid", response.bodyAsJsonObject().getString("message"));
 
@@ -949,9 +899,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Keyset id: " + input + " is not valid", response.bodyAsJsonObject().getString("message"));
 
@@ -978,9 +926,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Site id " + input + " not valid", response.bodyAsJsonObject().getString("message"));
 
@@ -1006,9 +952,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Duplicate site_ids not permitted", response.bodyAsJsonObject().getString("message"));
 
@@ -1034,9 +978,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Duplicate site_ids not permitted", response.bodyAsJsonObject().getString("message"));
 
@@ -1063,9 +1005,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(4, 8, "test", Set.of(5), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -1094,9 +1034,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"name\": \"test-name\"" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(1, 5, "test", Set.of(8), Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -1124,9 +1062,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"site_id\": 5" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(400, response.statusCode());
             assertEquals("Keyset already exists for site: 5", response.bodyAsJsonObject().getString("message"));
 
@@ -1150,9 +1086,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"site_id\": 3" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(2, 1, "test", null, Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -1179,9 +1113,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"allowed_sites\": null" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(2, 1, "test", null, Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -1207,9 +1139,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"keyset_id\": 1" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(1, 5, "test", null, Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -1236,9 +1166,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"allowed_sites\": null" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(1, 5, "test", null, Instant.now().getEpochSecond(), true, true, new HashSet<>());
@@ -1274,9 +1202,7 @@ public class SharingServiceTest extends ServiceTestBase {
                 "    \"site_id\": 8" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/keyset", body, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/sharing/keyset", body, response -> {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(6, 8, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, Set.of(ClientType.DSP, ClientType.ADVERTISER));

--- a/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
@@ -70,9 +70,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, testContext, "api/sharing/list/" + siteId, ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/sharing/list/" + siteId, response -> {
             assertEquals(200, response.statusCode());
 
             compareKeysetListToResult(keysets.get(siteId), response.bodyAsJsonObject().getJsonArray("allowed_sites"));
@@ -96,8 +94,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, testContext, "api/sharing/list/42", ar -> {
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/sharing/list/42", response -> {
             assertEquals(404, response.statusCode());
 
             testContext.completeNow();
@@ -359,9 +356,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, testContext, "api/sharing/lists", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/sharing/lists", response -> {
             assertEquals(200, response.statusCode());
 
             JsonArray respArray = response.bodyAsJsonArray();
@@ -391,9 +386,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, testContext, "api/sharing/keyset/1", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/sharing/keyset/1", response -> {
             assertEquals(200, response.statusCode());
 
             compareKeysetListToResult(keysets.get(1), response.bodyAsJsonObject().getJsonArray("allowed_sites"));
@@ -413,9 +406,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, testContext, "api/sharing/keyset/1", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/sharing/keyset/1", response -> {
             assertEquals(404, response.statusCode());
             assertEquals("Failed to find keyset for keyset_id: 1", response.bodyAsJsonObject().getString("message"));
 
@@ -434,9 +425,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, testContext, "api/sharing/keysets", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        get(vertx, testContext, "api/sharing/keysets", response -> {
             assertEquals(200, response.statusCode());
 
             JsonArray respArray = response.bodyAsJsonArray();

--- a/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
@@ -70,7 +70,7 @@ public class SharingServiceTest extends ServiceTestBase {
         }};
 
         setAdminKeysets(keysets);
-        get(vertx, "api/sharing/list/" + siteId, ar -> {
+        get(vertx, testContext, "api/sharing/list/" + siteId, ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());

--- a/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
@@ -78,7 +78,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void listSitesNoSites(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
 
-        get(vertx, "api/site/list", ar -> {
+        get(vertx, testContext, "api/site/list", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "listSitesNoSites",
@@ -101,7 +101,7 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(sites);
 
-        get(vertx, "api/site/list", ar -> {
+        get(vertx, testContext,  "api/site/list", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "listSitesHaveSites",
@@ -133,7 +133,7 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setClientKeys(clientKeys);
 
-        get(vertx, "api/site/list", ar -> {
+        get(vertx, testContext, "api/site/list", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "listSitesWithKeys",
@@ -161,7 +161,7 @@ public class SiteServiceTest extends ServiceTestBase {
 
         setSites(initialSites);
 
-        post(vertx, "api/site/add?name=test_site", "", ar -> {
+        post(vertx, testContext, "api/site/add?name=test_site", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "addSiteNoExistingSites",
@@ -192,7 +192,7 @@ public class SiteServiceTest extends ServiceTestBase {
 
         setSites(initialSites);
 
-        post(vertx, "api/site/add?name=test_site", "", ar -> {
+        post(vertx, testContext, "api/site/add?name=test_site", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "addSiteExistingSites",
@@ -223,7 +223,7 @@ public class SiteServiceTest extends ServiceTestBase {
 
         setSites(initialSites);
 
-        post(vertx, "api/site/add?name=test_site&types=DSP,ADVERTISER", "", ar -> {
+        post(vertx, testContext, "api/site/add?name=test_site&types=DSP,ADVERTISER", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -250,7 +250,7 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, "api/site/add?name=test_site&enabled=true", "", ar -> {
+        post(vertx, testContext,  "api/site/add?name=test_site&enabled=true", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "addSiteEnabled",
@@ -301,7 +301,7 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, "api/site/enable?id=3&enabled=true", "", ar -> {
+        post(vertx, testContext, "api/site/enable?id=3&enabled=true", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "enableSite",
@@ -331,7 +331,7 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, "api/site/enable?id=3&enabled=false", "", ar -> {
+        post(vertx, testContext, "api/site/enable?id=3&enabled=false", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "disableSite",
@@ -361,7 +361,7 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, "api/site/enable?id=3&enabled=true", "", ar -> {
+        post(vertx, testContext, "api/site/enable?id=3&enabled=true", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "enableSiteAlreadyEnabled",
@@ -392,7 +392,7 @@ public class SiteServiceTest extends ServiceTestBase {
 
         setSites(initialSites);
 
-        post(vertx, "api/site/set-types?id=3&types=DSP,ADVERTISER", "", ar -> {
+        post(vertx, testContext, "api/site/set-types?id=3&types=DSP,ADVERTISER", "", ar -> {
             assertTrue(ar.succeeded());
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
@@ -433,7 +433,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void domainNameNoSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/site/domain_names", "", ar -> {
+        post(vertx, testContext, "api/site/domain_names", "", ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("must specify site id", response.bodyAsJsonObject().getString("message"));
@@ -445,7 +445,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void domainNameMissingSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/site/domain_names?id=123", "", ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=123", "", ar -> {
             HttpResponse response = ar.result();
             assertEquals(404, response.statusCode());
             assertEquals("site not found", response.bodyAsJsonObject().getString("message"));
@@ -457,7 +457,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void domainNameInvalidSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/site/domain_names?id=2", "", ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=2", "", ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("must specify a valid site id", response.bodyAsJsonObject().getString("message"));
@@ -469,7 +469,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void domainNameBadSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/site/domain_names?id=asdf", "", ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=asdf", "", ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("unable to parse site id For input string: \"asdf\"", response.bodyAsJsonObject().getString("message"));
@@ -482,7 +482,7 @@ public class SiteServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(123, "name", true));
         JsonObject reqBody = new JsonObject();
-        post(vertx, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("required parameters: domain_names", response.bodyAsJsonObject().getString("message"));
@@ -497,7 +497,7 @@ public class SiteServiceTest extends ServiceTestBase {
         setSites(s);
         JsonObject reqBody = new JsonObject();
         reqBody.put("domain_names", new JsonArray());
-        post(vertx, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
             checkSiteResponse(s, response.bodyAsJsonObject());
@@ -516,7 +516,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("bad");
         reqBody.put("domain_names", names);
 
-        post(vertx, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("invalid domain name: bad", response.bodyAsJsonObject().getString("message"));
@@ -535,7 +535,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("bad.doesntexist");
         reqBody.put("domain_names", names);
 
-        post(vertx, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("invalid domain name: bad.doesntexist", response.bodyAsJsonObject().getString("message"));
@@ -555,7 +555,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("http://bad.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("duplicate domain_names not permitted", response.bodyAsJsonObject().getString("message"));
@@ -578,7 +578,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
             s.setDomainNames(Set.of("test.com", "test.net", "test.org", "test2.org", "test3.com"));
@@ -602,7 +602,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
             s.setDomainNames(Set.of("test.com", "test.net", "test.org", "test2.org", "test3.com"));
@@ -626,7 +626,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(200, response.statusCode());
             Site expected = new Site(124, "test_name", true, Set.of("test.com", "test.net", "test.org", "test2.org", "test3.com"));
@@ -650,7 +650,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("invalid domain name: bad", response.bodyAsJsonObject().getString("message"));
@@ -672,7 +672,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
+        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
             HttpResponse response = ar.result();
             assertEquals(400, response.statusCode());
             assertEquals("duplicate domain_names not permitted", response.bodyAsJsonObject().getString("message"));

--- a/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
@@ -8,10 +8,8 @@ import com.uid2.shared.auth.Role;
 import com.uid2.shared.model.Site;
 import com.uid2.shared.model.ClientType;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
@@ -234,21 +232,21 @@ public class SiteServiceTest extends ServiceTestBase {
     void addSiteExistingName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(3, "test_site", false));
-        post(vertx, testContext, "api/site/add?name=test_site", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/add?name=test_site", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     void addSiteEmptyName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(3, "test_site", false));
-        post(vertx, testContext, "api/site/add?name=", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/add?name=", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     void addSiteWhitespaceName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(3, "test_site", false));
-        post(vertx, testContext, "api/site/add?name=%20", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/add?name=%20", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -342,21 +340,21 @@ public class SiteServiceTest extends ServiceTestBase {
     void enableSiteUnknownSite(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(3, "test_site", false));
-        post(vertx, testContext, "api/site/enable?id=5&enabled=true", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/site/enable?id=5&enabled=true", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
     void enableSiteSpecialSite1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/site/enable?id=1&enabled=true", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/enable?id=1&enabled=true", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     void enableSiteSpecialSite2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/site/enable?id=2&enabled=true", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/enable?id=2&enabled=true", "", expectHttpStatus(testContext, 400));
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
@@ -155,11 +155,9 @@ public class SiteServiceTest extends ServiceTestBase {
 
         setSites(initialSites);
 
-        post(vertx, testContext, "api/site/add?name=test_site", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        post(vertx, testContext, "api/site/add?name=test_site", "", response -> {
             assertAll(
                     "addSiteNoExistingSites",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()}));
 
@@ -186,20 +184,12 @@ public class SiteServiceTest extends ServiceTestBase {
 
         setSites(initialSites);
 
-        post(vertx, testContext, "api/site/add?name=test_site", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        post(vertx, testContext, "api/site/add?name=test_site", "", response -> {
             assertAll(
                     "addSiteExistingSites",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()}));
-
-            try {
-                verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
             testContext.completeNow();
         });
     }
@@ -217,18 +207,10 @@ public class SiteServiceTest extends ServiceTestBase {
 
         setSites(initialSites);
 
-        post(vertx, testContext, "api/site/add?name=test_site&types=DSP,ADVERTISER", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/add?name=test_site&types=DSP,ADVERTISER", "", response -> {
             assertEquals(200, response.statusCode());
             checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()});
-
-            try {
-                verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
             testContext.completeNow();
         });
     }
@@ -244,20 +226,12 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, testContext, "api/site/add?name=test_site&enabled=true", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        post(vertx, testContext, "api/site/add?name=test_site&enabled=true", "", response -> {
             assertAll(
                     "addSiteEnabled",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()}));
-
-            try {
-                verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
             testContext.completeNow();
         });
     }
@@ -295,20 +269,12 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, testContext, "api/site/enable?id=3&enabled=true", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        post(vertx, testContext, "api/site/enable?id=3&enabled=true", "", response -> {
             assertAll(
                     "enableSite",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(updatedSites, new Object[]{response.bodyAsJsonObject()}));
-
-            try {
-                verify(storeWriter).upload(collectionOfSize(initialSites.length), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(storeWriter).upload(collectionOfSize(initialSites.length), isNull());
             testContext.completeNow();
         });
     }
@@ -325,20 +291,12 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, testContext, "api/site/enable?id=3&enabled=false", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        post(vertx, testContext, "api/site/enable?id=3&enabled=false", "", response -> {
             assertAll(
                     "disableSite",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(updatedSites, new Object[]{response.bodyAsJsonObject()}));
-
-            try {
-                verify(storeWriter).upload(collectionOfSize(initialSites.length), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(storeWriter).upload(collectionOfSize(initialSites.length), isNull());
             testContext.completeNow();
         });
     }
@@ -355,20 +313,12 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, testContext, "api/site/enable?id=3&enabled=true", "", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        post(vertx, testContext, "api/site/enable?id=3&enabled=true", "", response -> {
             assertAll(
                     "enableSiteAlreadyEnabled",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(updatedSites, new Object[]{response.bodyAsJsonObject()}));
-
-            try {
-                verify(storeWriter, times(0)).upload(any(), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(storeWriter, times(0)).upload(any(), isNull());
             testContext.completeNow();
         });
     }
@@ -386,18 +336,10 @@ public class SiteServiceTest extends ServiceTestBase {
 
         setSites(initialSites);
 
-        post(vertx, testContext, "api/site/set-types?id=3&types=DSP,ADVERTISER", "", ar -> {
-            assertTrue(ar.succeeded());
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/set-types?id=3&types=DSP,ADVERTISER", "", response -> {
             assertEquals(200, response.statusCode());
             checkSiteResponse(updatedSites, new Object[]{response.bodyAsJsonObject()});
-
-            try {
-                verify(storeWriter).upload(collectionOfSize(initialSites.length), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(storeWriter).upload(collectionOfSize(initialSites.length), isNull());
             testContext.completeNow();
         });
     }
@@ -427,8 +369,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void domainNameNoSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/site/domain_names", "", ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names", "", response -> {
             assertEquals(400, response.statusCode());
             assertEquals("must specify site id", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -439,8 +380,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void domainNameMissingSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/site/domain_names?id=123", "", ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=123", "", response -> {
             assertEquals(404, response.statusCode());
             assertEquals("site not found", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -451,8 +391,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void domainNameInvalidSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/site/domain_names?id=2", "", ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=2", "", response -> {
             assertEquals(400, response.statusCode());
             assertEquals("must specify a valid site id", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -463,8 +402,7 @@ public class SiteServiceTest extends ServiceTestBase {
     void domainNameBadSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, testContext, "api/site/domain_names?id=asdf", "", ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=asdf", "", response -> {
             assertEquals(400, response.statusCode());
             assertEquals("unable to parse site id For input string: \"asdf\"", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -476,8 +414,7 @@ public class SiteServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(123, "name", true));
         JsonObject reqBody = new JsonObject();
-        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("required parameters: domain_names", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -491,8 +428,7 @@ public class SiteServiceTest extends ServiceTestBase {
         setSites(s);
         JsonObject reqBody = new JsonObject();
         reqBody.put("domain_names", new JsonArray());
-        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), response -> {
             assertEquals(200, response.statusCode());
             checkSiteResponse(s, response.bodyAsJsonObject());
             testContext.completeNow();
@@ -510,8 +446,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("bad");
         reqBody.put("domain_names", names);
 
-        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("invalid domain name: bad", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -529,8 +464,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("bad.doesntexist");
         reqBody.put("domain_names", names);
 
-        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("invalid domain name: bad.doesntexist", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -549,8 +483,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("http://bad.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("duplicate domain_names not permitted", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();
@@ -572,8 +505,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), response -> {
             assertEquals(200, response.statusCode());
             s.setDomainNames(Set.of("test.com", "test.net", "test.org", "test2.org", "test3.com"));
             checkSiteResponse(s, response.bodyAsJsonObject());
@@ -596,8 +528,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/domain_names?id=123", reqBody.encode(), response -> {
             assertEquals(200, response.statusCode());
             s.setDomainNames(Set.of("test.com", "test.net", "test.org", "test2.org", "test3.com"));
             checkSiteResponse(s, response.bodyAsJsonObject());
@@ -620,8 +551,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), response -> {
             assertEquals(200, response.statusCode());
             Site expected = new Site(124, "test_name", true, Set.of("test.com", "test.net", "test.org", "test2.org", "test3.com"));
             checkSiteResponse(expected, response.bodyAsJsonObject());
@@ -644,8 +574,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("invalid domain name: bad", response.bodyAsJsonObject().getString("message"));
             assertEquals("invalid domain name: bad", response.bodyAsJsonObject().getString("message"));
@@ -666,8 +595,7 @@ public class SiteServiceTest extends ServiceTestBase {
         names.add("blah.test3.com");
         reqBody.put("domain_names", names);
 
-        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), ar -> {
-            HttpResponse response = ar.result();
+        post(vertx, testContext, "api/site/add?name=test_name&enabled=true", reqBody.encode(), response -> {
             assertEquals(400, response.statusCode());
             assertEquals("duplicate domain_names not permitted", response.bodyAsJsonObject().getString("message"));
             testContext.completeNow();

--- a/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
@@ -160,13 +160,7 @@ public class SiteServiceTest extends ServiceTestBase {
                     "addSiteNoExistingSites",
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()}));
-
-            try {
-                verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
-            } catch (Exception ex) {
-                fail(ex);
-            }
-
+            verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
             testContext.completeNow();
         });
     }
@@ -240,21 +234,21 @@ public class SiteServiceTest extends ServiceTestBase {
     void addSiteExistingName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(3, "test_site", false));
-        post(vertx, "api/site/add?name=test_site", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/add?name=test_site", "", expectHttpError(testContext, 400));
     }
 
     @Test
     void addSiteEmptyName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(3, "test_site", false));
-        post(vertx, "api/site/add?name=", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/add?name=", "", expectHttpError(testContext, 400));
     }
 
     @Test
     void addSiteWhitespaceName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(3, "test_site", false));
-        post(vertx, "api/site/add?name=%20", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/add?name=%20", "", expectHttpError(testContext, 400));
     }
 
     @Test
@@ -348,21 +342,21 @@ public class SiteServiceTest extends ServiceTestBase {
     void enableSiteUnknownSite(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites(new Site(3, "test_site", false));
-        post(vertx, "api/site/enable?id=5&enabled=true", "", expectHttpError(testContext, 404));
+        post(vertx, testContext, "api/site/enable?id=5&enabled=true", "", expectHttpError(testContext, 404));
     }
 
     @Test
     void enableSiteSpecialSite1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/site/enable?id=1&enabled=true", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/enable?id=1&enabled=true", "", expectHttpError(testContext, 400));
     }
 
     @Test
     void enableSiteSpecialSite2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setSites();
-        post(vertx, "api/site/enable?id=2&enabled=true", "", expectHttpError(testContext, 400));
+        post(vertx, testContext, "api/site/enable?id=2&enabled=true", "", expectHttpError(testContext, 400));
     }
 
     @Test

--- a/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
@@ -72,6 +72,13 @@ public class SiteServiceTest extends ServiceTestBase {
                 () -> assertTrue(actualRoles.containsAll(List.of(roles))));
     }
 
+    private void checkSiteResponseWithoutCreatedAt(Site expectedSite, JsonObject actualSite) {
+        assertEquals(expectedSite.getId(), actualSite.getInteger("id"));
+        assertEquals(expectedSite.getName(), actualSite.getString("name"));
+        assertEquals(expectedSite.isEnabled(), actualSite.getBoolean("enabled"));
+        assertEquals(expectedSite.getDomainNames(), actualSite.getJsonArray("domain_names").stream().collect(Collectors.toSet()));
+    }
+
     @Test
     void listSitesNoSites(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
@@ -147,9 +154,7 @@ public class SiteServiceTest extends ServiceTestBase {
 
         Site[] initialSites = {
         };
-        Site[] addedSites = {
-                new Site(3, "test_site", false),
-        };
+        Site addedSites = new Site(3, "test_site", false);
 
         setSites(initialSites);
 
@@ -157,7 +162,7 @@ public class SiteServiceTest extends ServiceTestBase {
             assertAll(
                     "addSiteNoExistingSites",
                     () -> assertEquals(200, response.statusCode()),
-                    () -> checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()}));
+                    () -> checkSiteResponseWithoutCreatedAt(addedSites, response.bodyAsJsonObject()));
             verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
             testContext.completeNow();
         });
@@ -170,9 +175,7 @@ public class SiteServiceTest extends ServiceTestBase {
         Site[] initialSites = {
                 new Site(7, "initial_site", false),
         };
-        Site[] addedSites = {
-                new Site(8, "test_site", false),
-        };
+        Site addedSites = new Site(8, "test_site", false);
 
         setSites(initialSites);
 
@@ -180,7 +183,7 @@ public class SiteServiceTest extends ServiceTestBase {
             assertAll(
                     "addSiteExistingSites",
                     () -> assertEquals(200, response.statusCode()),
-                    () -> checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()}));
+                    () -> checkSiteResponseWithoutCreatedAt(addedSites, response.bodyAsJsonObject()));
             verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
             testContext.completeNow();
         });
@@ -193,15 +196,12 @@ public class SiteServiceTest extends ServiceTestBase {
         Site[] initialSites = {
                 new Site(7, "initial_site", false),
         };
-        Site[] addedSites = {
-                new Site(8, "test_site", false, Set.of(ClientType.DSP, ClientType.ADVERTISER), new HashSet<>()),
-        };
-
+        Site addedSites = new Site(8, "test_site", false, Set.of(ClientType.DSP, ClientType.ADVERTISER), new HashSet<>());
         setSites(initialSites);
 
         post(vertx, testContext, "api/site/add?name=test_site&types=DSP,ADVERTISER", "", response -> {
             assertEquals(200, response.statusCode());
-            checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()});
+            checkSiteResponseWithoutCreatedAt(addedSites, response.bodyAsJsonObject());
             verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
             testContext.completeNow();
         });
@@ -213,16 +213,14 @@ public class SiteServiceTest extends ServiceTestBase {
 
         Site[] initialSites = {
         };
-        Site[] addedSites = {
-                new Site(3, "test_site", true),
-        };
+        Site addedSites = new Site(3, "test_site", true);
         setSites(initialSites);
 
         post(vertx, testContext, "api/site/add?name=test_site&enabled=true", "", response -> {
             assertAll(
                     "addSiteEnabled",
                     () -> assertEquals(200, response.statusCode()),
-                    () -> checkSiteResponse(addedSites, new Object[]{response.bodyAsJsonObject()}));
+                    () -> checkSiteResponseWithoutCreatedAt(addedSites, response.bodyAsJsonObject()));
             verify(storeWriter).upload(collectionOfSize(initialSites.length + 1), isNull());
             testContext.completeNow();
         });

--- a/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
@@ -101,7 +101,7 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(sites);
 
-        get(vertx, testContext,  "api/site/list", ar -> {
+        get(vertx, testContext, "api/site/list", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "listSitesHaveSites",
@@ -250,7 +250,7 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(initialSites);
 
-        post(vertx, testContext,  "api/site/add?name=test_site&enabled=true", "", ar -> {
+        post(vertx, testContext, "api/site/add?name=test_site&enabled=true", "", ar -> {
             HttpResponse<Buffer> response = ar.result();
             assertAll(
                     "addSiteEnabled",

--- a/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SiteServiceTest.java
@@ -78,11 +78,9 @@ public class SiteServiceTest extends ServiceTestBase {
     void listSitesNoSites(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
 
-        get(vertx, testContext, "api/site/list", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        get(vertx, testContext, "api/site/list", response -> {
             assertAll(
                     "listSitesNoSites",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> assertEquals(0, response.bodyAsJsonArray().stream().count()));
 
@@ -101,11 +99,9 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setSites(sites);
 
-        get(vertx, testContext, "api/site/list", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        get(vertx, testContext, "api/site/list", response -> {
             assertAll(
                     "listSitesHaveSites",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(sites, response.bodyAsJsonArray().stream().toArray()));
 
@@ -133,11 +129,9 @@ public class SiteServiceTest extends ServiceTestBase {
         };
         setClientKeys(clientKeys);
 
-        get(vertx, testContext, "api/site/list", ar -> {
-            HttpResponse<Buffer> response = ar.result();
+        get(vertx, testContext, "api/site/list", response -> {
             assertAll(
                     "listSitesWithKeys",
-                    () -> assertTrue(ar.succeeded()),
                     () -> assertEquals(200, response.statusCode()),
                     () -> checkSiteResponse(sites, response.bodyAsJsonArray().stream().toArray()),
                     () -> checkSiteResponseWithKeys(response.bodyAsJsonArray().stream().toArray(), 11, 2, Role.GENERATOR, Role.ID_READER, Role.MAPPER),

--- a/src/test/java/com/uid2/admin/vertx/test/ExceptionHandler.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ExceptionHandler.java
@@ -1,0 +1,6 @@
+package com.uid2.admin.vertx.test;
+
+@FunctionalInterface
+public interface ExceptionHandler<T> {
+    void handle(T t) throws Exception;
+}

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -46,8 +46,7 @@ import lombok.val;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
@@ -288,9 +287,12 @@ public abstract class ServiceTestBase {
     protected static Handler<AsyncResult<HttpResponse<Buffer>>> expectHttpError(VertxTestContext testContext, int errorCode) {
         return ar -> {
             try {
-                assertTrue(ar.succeeded());
                 HttpResponse response = ar.result();
-                assertEquals(errorCode, response.statusCode());
+                assertAll(
+                        "expectHttpError",
+                        () -> assertTrue(ar.succeeded()),
+                        () -> assertEquals(errorCode, response.statusCode())
+                );
                 testContext.completeNow();
             } catch (Throwable t) {
                 testContext.failNow(t);

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -25,9 +25,6 @@ import com.uid2.shared.store.ClientSideKeypairStoreSnapshot;
 import com.uid2.shared.store.IKeyStore;
 import com.uid2.shared.store.KeysetKeyStoreSnapshot;
 import com.uid2.shared.store.reader.*;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
@@ -42,7 +39,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import lombok.val;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -264,7 +260,7 @@ public abstract class ServiceTestBase {
         }
     }
 
-    protected static TestHandler<HttpResponse<Buffer>> expectHttpError(VertxTestContext testContext, int errorCode) {
+    protected static TestHandler<HttpResponse<Buffer>> expectHttpStatus(VertxTestContext testContext, int errorCode) {
         return response -> {
             assertEquals(errorCode, response.statusCode());
             testContext.completeNow();

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -26,6 +26,7 @@ import com.uid2.shared.store.IKeyStore;
 import com.uid2.shared.store.KeysetKeyStoreSnapshot;
 import com.uid2.shared.store.reader.*;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -162,14 +163,9 @@ public abstract class ServiceTestBase {
         post(vertx, endpoint, body, wrappedHandler);
     }
 
-    protected void postWithoutBody(Vertx vertx, String endpoint, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {
+    protected Future<HttpResponse<Buffer>> postWithoutBody(Vertx vertx, String endpoint) {
         WebClient client = WebClient.create(vertx);
-        client.postAbs(getUrlForEndpoint(endpoint)).sendBuffer(null, handler);
-    }
-
-    protected void postWithoutBody(Vertx vertx, VertxTestContext testContext, String endpoint, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {
-        val wrappedHandler = wrapHandlerToCatchAssertionErrors(testContext, handler);
-        postWithoutBody(vertx, endpoint, wrappedHandler);
+        return client.postAbs(getUrlForEndpoint(endpoint)).sendBuffer(null);
     }
 
     protected static Handler<AsyncResult<HttpResponse<Buffer>>> wrapHandlerToCatchAssertionErrors(VertxTestContext testContext, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -285,19 +285,10 @@ public abstract class ServiceTestBase {
     }
 
     protected static Handler<AsyncResult<HttpResponse<Buffer>>> expectHttpError(VertxTestContext testContext, int errorCode) {
-        return ar -> {
-            try {
-                HttpResponse response = ar.result();
-                assertAll(
-                        "expectHttpError",
-                        () -> assertTrue(ar.succeeded()),
-                        () -> assertEquals(errorCode, response.statusCode())
-                );
-                testContext.completeNow();
-            } catch (Throwable t) {
-                testContext.failNow(t);
-            }
-        };
+        return testContext.succeeding(response -> {
+            assertEquals(errorCode, response.statusCode());
+            testContext.completeNow();
+        });
     }
 
     protected EncryptionKeyAcl makeKeyAcl(boolean isWhitelist, Integer... siteIds) {

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -150,11 +150,6 @@ public abstract class ServiceTestBase {
                 .onComplete(testContext.succeeding(response -> testContext.verify(() -> handler.handle(response))));
     }
 
-    protected void post(Vertx vertx, String endpoint, String body, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {
-        WebClient client = WebClient.create(vertx);
-        client.postAbs(getUrlForEndpoint(endpoint)).sendBuffer(Buffer.buffer(body), handler);
-    }
-
     protected void post(Vertx vertx, VertxTestContext testContext, String endpoint, String body, TestHandler<HttpResponse<Buffer>> handler) {
         WebClient client = WebClient.create(vertx);
         client.postAbs(getUrlForEndpoint(endpoint))
@@ -269,11 +264,11 @@ public abstract class ServiceTestBase {
         }
     }
 
-    protected static Handler<AsyncResult<HttpResponse<Buffer>>> expectHttpError(VertxTestContext testContext, int errorCode) {
-        return testContext.succeeding(response -> {
+    protected static TestHandler<HttpResponse<Buffer>> expectHttpError(VertxTestContext testContext, int errorCode) {
+        return response -> {
             assertEquals(errorCode, response.statusCode());
             testContext.completeNow();
-        });
+        };
     }
 
     protected EncryptionKeyAcl makeKeyAcl(boolean isWhitelist, Integer... siteIds) {

--- a/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
+++ b/src/test/java/com/uid2/admin/vertx/test/ServiceTestBase.java
@@ -143,14 +143,14 @@ public abstract class ServiceTestBase {
         when(adminUserProvider.get(any())).thenReturn(adminUser);
     }
 
-    protected void get(Vertx vertx, String endpoint, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {
+    protected Future<HttpResponse<Buffer>> get(Vertx vertx, String endpoint) {
         WebClient client = WebClient.create(vertx);
-        client.getAbs(getUrlForEndpoint(endpoint)).send(handler);
+        return client.getAbs(getUrlForEndpoint(endpoint)).send();
     }
 
     protected void get(Vertx vertx, VertxTestContext testContext, String endpoint, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {
         val wrappedHandler = wrapHandlerToCatchAssertionErrors(testContext, handler);
-        get(vertx, endpoint, wrappedHandler);
+        get(vertx, endpoint).onComplete(wrappedHandler);
     }
 
     protected void post(Vertx vertx, String endpoint, String body, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {

--- a/src/test/java/com/uid2/admin/vertx/test/TestHandler.java
+++ b/src/test/java/com/uid2/admin/vertx/test/TestHandler.java
@@ -1,6 +1,6 @@
 package com.uid2.admin.vertx.test;
 
 @FunctionalInterface
-public interface ExceptionHandler<T> {
+public interface TestHandler<T> {
     void handle(T t) throws Exception;
 }


### PR DESCRIPTION
- Fixed failed test not complete until 30s timeout 

before surround with try-catch
![beforeCatch](https://github.com/IABTechLab/uid2-admin/assets/116539741/d71eb866-758e-4067-a1fe-7e0bffc22772)

after surround with try-catch
![afterCatch](https://github.com/IABTechLab/uid2-admin/assets/116539741/c76d876f-1263-4b55-95a4-2d26b7602c94)

- Fixed multiple async asynchronous executions in a single test will not fail the test if any of the asynchronous execution is successful 
![image](https://github.com/IABTechLab/uid2-admin/assets/116539741/41d4de1b-83e8-488f-adf0-2179c0099ed2)
