### PR TITLE
Allow updating new site fields in UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.1.0</micrometer.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <uid2-shared.version>5.17.0-7c1a08e2f9</uid2-shared.version>
+        <uid2-shared.version>5.18.0-d6c76f6aab</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.1.0</micrometer.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <uid2-shared.version>5.15.0-5e9fa2fc04</uid2-shared.version>
+        <uid2-shared.version>5.17.0-7c1a08e2f9</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
     <repositories>

--- a/src/main/java/com/uid2/admin/vertx/service/SiteService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/SiteService.java
@@ -187,12 +187,14 @@ public class SiteService implements IService {
                 types = getTypes(rc.queryParam("types").get(0));
             }
 
+            String description = rc.queryParam("description").stream().findFirst().orElse(null);
+
             final List<Site> sites = this.siteProvider.getAllSites()
                     .stream().sorted(Comparator.comparingInt(Site::getId))
                     .collect(Collectors.toList());
             final int siteId = 1 + sites.stream().mapToInt(Site::getId).max().orElse(Const.Data.AdvertisingTokenSiteId);
-            final Site newSite = new Site(siteId, name, enabled, types, new HashSet<>(normalizedDomainNames));
 
+            final Site newSite = new Site(siteId, name, description, enabled, types, new HashSet<>(normalizedDomainNames), true);
             // add site to the array
             sites.add(newSite);
 

--- a/src/main/java/com/uid2/admin/vertx/service/SiteService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/SiteService.java
@@ -72,10 +72,10 @@ public class SiteService implements IService {
             }
         }, Role.CLIENTKEY_ISSUER));
         router.post("/api/site/set-types").blockingHandler(auth.handle((ctx) -> {
-                    synchronized (writeLock) {
-                        this.handleSiteTypesSet(ctx);
-                    }
-                    }, Role.CLIENTKEY_ISSUER));
+            synchronized (writeLock) {
+                this.handleSiteTypesSet(ctx);
+            }
+        }, Role.CLIENTKEY_ISSUER));
         router.post("/api/site/domain_names").blockingHandler(auth.handle((ctx) -> {
             synchronized (writeLock) {
                 this.handleSiteDomains(ctx);
@@ -160,7 +160,7 @@ public class SiteService implements IService {
                 JsonArray domainNamesJa = body.getJsonArray("domain_names");
                 if (domainNamesJa != null) {
                     normalizedDomainNames = getNormalizedDomainNames(rc, domainNamesJa);
-                    if(normalizedDomainNames == null) return;
+                    if (normalizedDomainNames == null) return;
                 }
             }
 
@@ -176,8 +176,7 @@ public class SiteService implements IService {
             }
 
             Set<ClientType> types = new HashSet<>();
-            if(!rc.queryParam("types").isEmpty())
-            {
+            if (!rc.queryParam("types").isEmpty()) {
                 types = getTypes(rc.queryParam("types").get(0));
             }
 
@@ -208,7 +207,7 @@ public class SiteService implements IService {
             }
 
             Set<ClientType> types = getTypes(rc.queryParam("types").get(0));
-            if(types == null) {
+            if (types == null) {
                 ResponseUtil.error(rc, 400, "Invalid Types");
                 return;
             }
@@ -275,7 +274,7 @@ public class SiteService implements IService {
 
             JsonObject body = rc.body().asJsonObject();
             JsonArray domainNamesJa = body.getJsonArray("domain_names");
-            if(domainNamesJa == null) {
+            if (domainNamesJa == null) {
                 ResponseUtil.error(rc, 400, "required parameters: domain_names");
                 return;
             }
@@ -300,7 +299,7 @@ public class SiteService implements IService {
         List<String> domainNames = domainNamesJa.stream().map(String::valueOf).collect(Collectors.toList());
 
         List<String> normalizedDomainNames = new ArrayList<>();
-        for(String domain : domainNames) {
+        for (String domain : domainNames) {
             try {
                 String tld = getTopLevelDomainName(domain);
                 normalizedDomainNames.add(tld);
@@ -329,11 +328,10 @@ public class SiteService implements IService {
         //InternetDomainName will normalise the domain name to lower case already
         InternetDomainName name = InternetDomainName.from(host);
         //if the domain name has a proper TLD suffix
-        if(name.isUnderPublicSuffix()) {
+        if (name.isUnderPublicSuffix()) {
             try {
                 return name.topPrivateDomain().toString();
-            }
-            catch(Exception e) {
+            } catch (Exception e) {
                 throw e;
             }
         }

--- a/src/main/resources/localstack/s3/sites/sites.json
+++ b/src/main/resources/localstack/s3/sites/sites.json
@@ -2,6 +2,7 @@
   {
     "id": 999,
     "name": "Special",
+    "description": "A special description",
     "enabled": true,
     "clientTypes": ["DSP", "PUBLISHER", "DATA_PROVIDER", "ADVERTISER"]
   },
@@ -37,7 +38,8 @@
   {
     "id": 128,
     "name": "Legacy DSP",
-    "enabled": true
+    "enabled": true,
+    "visible": false
   },
   {
     "id": 129,

--- a/src/main/resources/localstack/s3/sites/sites.json
+++ b/src/main/resources/localstack/s3/sites/sites.json
@@ -4,31 +4,36 @@
     "name": "Special",
     "description": "A special description",
     "enabled": true,
-    "clientTypes": ["DSP", "PUBLISHER", "DATA_PROVIDER", "ADVERTISER"]
+    "clientTypes": ["DSP", "PUBLISHER", "DATA_PROVIDER", "ADVERTISER"],
+    "visible": true
   },
   {
     "id": 123,
     "name": "DSP",
     "enabled": true,
-    "clientTypes": ["DSP"]
+    "clientTypes": ["DSP"],
+    "visible": true
   },
   {
     "id": 124,
     "name": "Publisher",
     "enabled": true,
-    "clientTypes": ["PUBLISHER"]
+    "clientTypes": ["PUBLISHER"],
+    "visible": true
   },
   {
     "id": 125,
     "name": "Data Provider",
     "enabled": true,
-    "clientTypes": ["DATA_PROVIDER"]
+    "clientTypes": ["DATA_PROVIDER"],
+    "visible": true
   },
   {
     "id": 126,
     "name": "Advertiser",
     "enabled": true,
-    "clientTypes": ["ADVERTISER"]
+    "clientTypes": ["ADVERTISER"],
+    "visible": true
   },
   {
     "id": 127,
@@ -44,16 +49,19 @@
   {
     "id": 129,
     "name": "Legacy Publisher",
-    "enabled": true
+    "enabled": true,
+    "visible": false
   },
   {
     "id": 130,
     "name": "Legacy Data Provider",
-    "enabled": true
+    "enabled": true,
+    "visible": false
   },
   {
-    "id": 130,
+    "id": 131,
     "name": "Legacy Advertiser",
-    "enabled": true
+    "enabled": true,
+    "visible": false
   }
 ]

--- a/webroot/adm/site.html
+++ b/webroot/adm/site.html
@@ -18,6 +18,8 @@
     <input type="text" id="siteName" name="siteName">
     <label for="siteId">Site Id:</label>
     <input type="text" id="siteId" name="siteId">
+    <label for="description">Description:</label>
+    <input type="text" id="description" name="description">
     <label for="types">Client Types:</label>
     <input type="text" id="types" name="types">
 </div>
@@ -37,8 +39,11 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doAdd">Add Site</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doEnable">Enable Site</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doDisable">Disable Site</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doSetDescription">Set Description</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doSetTypes">Set Types</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doDomainNames">Set Site Domain Names</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doSetVisible">Set Visible</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doSetNotVisible">Set Not Visible</a></li>
 </ul>
 
 <br>
@@ -101,6 +106,32 @@
             const payload = { domain_names: domainNames }
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput', JSON.stringify(payload));
+        });
+
+        $('#doSetDescription').on('click', function () {
+            var siteId = encodeURIComponent($('#siteId').val());
+
+            var description = encodeURIComponent($('#description').val());
+
+            var url = '/api/site/update?id=' + siteId + '&description=' + description;
+
+            doApiCall('POST', url, '#standardOutput', '#errorOutput');
+        });
+
+        $('#doSetVisible').on('click', function () {
+            var siteId = encodeURIComponent($('#siteId').val());
+
+            var url = '/api/site/update?id=' + siteId + '&visible=true';
+
+            doApiCall('POST', url, '#standardOutput', '#errorOutput');
+        });
+
+        $('#doSetNotVisible').on('click', function () {
+            var siteId = encodeURIComponent($('#siteId').val());
+
+            var url = '/api/site/update?id=' + siteId + '&visible=false';
+
+            doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
     });
 </script>

--- a/webroot/adm/site.html
+++ b/webroot/adm/site.html
@@ -64,7 +64,8 @@
         $('#doAdd').on('click', function () {
             var siteName = encodeURIComponent($('#siteName').val());
             var types = encodeURIComponent($('#types').val());
-            var url = '/api/site/add?name=' + siteName + '&types=' + types;
+            var description = encodeURIComponent($('#description').val());
+            var url = '/api/site/add?name=' + siteName + '&types=' + types + '&description=' + description;
 
             let domainNames = ($('#domainNames').val()).replace(/\s+/g, '').split(',').filter( (value, _, __) => value !== "");
             doApiCall('POST', url, '#standardOutput', '#errorOutput', JSON.stringify({domain_names : domainNames}));


### PR DESCRIPTION
- New api endpoint `/api/site/update` which currently handles `description` and `visible`
- Allow `description` to be passed to add site method
- Add buttons to the UI to set description and visible 
- The first commit is purely formatting changes
- Relevant changes in shared: https://github.com/IABTechLab/uid2-shared/pull/157

## Local Testing

**Listing sites**

https://github.com/IABTechLab/uid2-admin/assets/137864392/b1e90df9-2c10-448f-9e71-b18cad30b907

**Adding a new site with a description**

https://github.com/IABTechLab/uid2-admin/assets/137864392/091db096-4251-452c-aa4f-8ae05b5ab986

**Adding a site with no description**

https://github.com/IABTechLab/uid2-admin/assets/137864392/7814cc9c-c99f-4147-9b94-4cabb04a4f74

**Updating a site**

https://github.com/IABTechLab/uid2-admin/assets/137864392/90d5f466-187d-429e-a3b3-9261d9e549c3

**Updating a site that has a null `visible`**

https://github.com/IABTechLab/uid2-admin/assets/137864392/96822ede-9e47-4ad0-a155-452ec7cf0503



