### PR TITLE
Prevent NPE when updating allowed_sites from null

### DIFF
--- a/src/main/java/com/uid2/admin/vertx/service/SharingService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/SharingService.java
@@ -345,9 +345,11 @@ public class SharingService implements IService {
         final Set<Integer> newlist;
 
         if (allowedSites != null){
-            final Set<Integer> existingAllowedSites = existingSites;
+            final Set<Integer> existingAllowedSites = (existingSites != null) ? existingSites : new HashSet<>();
             OptionalInt firstInvalidSite = allowedSites.stream()
-                    .mapToInt(s -> (Integer) s).filter(s -> !existingAllowedSites.contains(s) && !isSiteIdEditable(s)).findFirst();
+                    .mapToInt(s -> (Integer) s)
+                    .filter(s -> !existingAllowedSites.contains(s) && !isSiteIdEditable(s))
+                    .findFirst();
             if (firstInvalidSite.isPresent()) {
                 ResponseUtil.error(rc, 400, "Site id " + firstInvalidSite.getAsInt() + " not valid");
                 return null;

--- a/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
@@ -155,7 +155,7 @@ public class SharingServiceTest extends ServiceTestBase {
         final int anotherSiteId = 22;
 
         Map<Integer, AdminKeyset> keysets = new HashMap<Integer, AdminKeyset>() {{
-            put(myKeysetId, new AdminKeyset(myKeysetId, mySiteId, "test", null, Instant.now().getEpochSecond(),true, true, new HashSet<>()));
+            put(myKeysetId, new AdminKeyset(myKeysetId, mySiteId, "test", null, Instant.now().getEpochSecond(), true, true, new HashSet<>()));
         }};
         mockSiteExistence(mySiteId, anotherSiteId);
 

--- a/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
@@ -150,29 +150,31 @@ public class SharingServiceTest extends ServiceTestBase {
     void listSiteSetWithNullExistingAllowedSites(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.SHARING_PORTAL);
 
+        final int myKeysetId = 3;
+        final int mySiteId = 5;
+        final int anotherSiteId = 22;
+
         Map<Integer, AdminKeyset> keysets = new HashMap<Integer, AdminKeyset>() {{
-            put(3, new AdminKeyset(3, 5, "test", null, Instant.now().getEpochSecond(),true, true, new HashSet<>()));
-            put(5, new AdminKeyset(5, 4, "test", Set.of(5), Instant.now().getEpochSecond(),true, true, new HashSet<>()));
+            put(myKeysetId, new AdminKeyset(myKeysetId, mySiteId, "test", null, Instant.now().getEpochSecond(),true, true, new HashSet<>()));
         }};
-        mockSiteExistence(5,4,22,25,6);
+        mockSiteExistence(mySiteId, anotherSiteId);
 
         setAdminKeysets(keysets);
-        mockSiteExistence(5,4);
 
         String body = "  {\n" +
                 "    \"allowed_sites\": [\n" +
-                "      22\n" +
+                "      " + anotherSiteId + "\n" +
                 "    ],\n" +
-                "    \"hash\": " + keysets.get(3).hashCode() + "\n" +
+                "    \"hash\": " + keysets.get(myKeysetId).hashCode() + "\n" +
                 "  }";
 
-        post(vertx, testContext, "api/sharing/list/5", body, response -> {
+        post(vertx, testContext, "api/sharing/list/" + mySiteId, body, response -> {
             assertEquals(200, response.statusCode());
 
-            AdminKeyset expected = new AdminKeyset(3, 5, "test", Set.of(22), Instant.now().getEpochSecond(), true, true, new HashSet<>());
+            AdminKeyset expected = new AdminKeyset(myKeysetId, mySiteId, "test", Set.of(anotherSiteId), Instant.now().getEpochSecond(), true, true, new HashSet<>());
             compareKeysetListToResult(expected, response.bodyAsJsonObject().getJsonArray("allowed_sites"));
 
-            assertEquals(expected.getAllowedSites(), keysets.get(3).getAllowedSites());
+            assertEquals(expected.getAllowedSites(), keysets.get(myKeysetId).getAllowedSites());
             testContext.completeNow();
         });
     }

--- a/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/SharingServiceTest.java
@@ -1,19 +1,18 @@
 package com.uid2.admin.vertx;
 
-import com.uid2.shared.model.ClientType;
+import com.uid2.admin.auth.AdminKeyset;
 import com.uid2.admin.managers.KeysetManager;
 import com.uid2.admin.vertx.service.IService;
 import com.uid2.admin.vertx.service.SharingService;
 import com.uid2.admin.vertx.test.ServiceTestBase;
 import com.uid2.shared.Const;
 import com.uid2.shared.auth.Role;
+import com.uid2.shared.model.ClientType;
 import com.uid2.shared.model.Site;
-import com.uid2.admin.auth.AdminKeyset;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
-import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,13 +21,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.*;
 
 public class SharingServiceTest extends ServiceTestBase {
     @Override
@@ -136,6 +139,37 @@ public class SharingServiceTest extends ServiceTestBase {
             assertEquals(200, response.statusCode());
 
             AdminKeyset expected = new AdminKeyset(3, 5, "test", Set.of(22, 25, 6), Instant.now().getEpochSecond(), true, true, new HashSet<>());
+            compareKeysetListToResult(expected, response.bodyAsJsonObject().getJsonArray("allowed_sites"));
+
+            assertEquals(expected.getAllowedSites(), keysets.get(3).getAllowedSites());
+            testContext.completeNow();
+        });
+    }
+
+    @Test
+    void listSiteSetWithNullExistingAllowedSites(Vertx vertx, VertxTestContext testContext) {
+        fakeAuth(Role.SHARING_PORTAL);
+
+        Map<Integer, AdminKeyset> keysets = new HashMap<Integer, AdminKeyset>() {{
+            put(3, new AdminKeyset(3, 5, "test", null, Instant.now().getEpochSecond(),true, true, new HashSet<>()));
+            put(5, new AdminKeyset(5, 4, "test", Set.of(5), Instant.now().getEpochSecond(),true, true, new HashSet<>()));
+        }};
+        mockSiteExistence(5,4,22,25,6);
+
+        setAdminKeysets(keysets);
+        mockSiteExistence(5,4);
+
+        String body = "  {\n" +
+                "    \"allowed_sites\": [\n" +
+                "      22\n" +
+                "    ],\n" +
+                "    \"hash\": " + keysets.get(3).hashCode() + "\n" +
+                "  }";
+
+        post(vertx, testContext, "api/sharing/list/5", body, response -> {
+            assertEquals(200, response.statusCode());
+
+            AdminKeyset expected = new AdminKeyset(3, 5, "test", Set.of(22), Instant.now().getEpochSecond(), true, true, new HashSet<>());
             compareKeysetListToResult(expected, response.bodyAsJsonObject().getJsonArray("allowed_sites"));
 
             assertEquals(expected.getAllowedSites(), keysets.get(3).getAllowedSites());
@@ -574,6 +608,7 @@ public class SharingServiceTest extends ServiceTestBase {
         };
     }*/
 
+    @Test
     void KeysetCanUpdateAllowedSites(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.ADMINISTRATOR);
 


### PR DESCRIPTION
`!existingAllowedSites.contains(s)` was causing an NPE when `existingAllowedSites` was `null`. This PR fixes that issue and adds a test for this situation.

**Manual tests in the Portal**
No longer receives a 500 from admin and crashes when `allowed_sites` is `null` - it now works as you would expect.

https://github.com/IABTechLab/uid2-admin/assets/137864392/4d0aed60-1d33-4b5c-8998-bc0155dc7a35

**Manual tests in Admin UI**
Preserves functionality.

https://github.com/IABTechLab/uid2-admin/assets/137864392/8d25e09e-5223-440e-a2c0-da710041640f



