### PR TITLE
Ensure roles are consistent for portal

### DIFF
--- a/src/main/java/com/uid2/admin/vertx/service/ClientSideKeypairService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/ClientSideKeypairService.java
@@ -68,7 +68,7 @@ public class ClientSideKeypairService implements IService, IKeypairManager {
             synchronized (writeLock) {
                 this.handleAddKeypair(ctx);
             }
-        }, Role.ADMINISTRATOR));
+        }, Role.ADMINISTRATOR, Role.SHARING_PORTAL));
         router.post("/api/client_side_keypairs/update").blockingHandler(auth.handle((ctx) -> {
             synchronized (writeLock) {
                 this.handleUpdateKeypair(ctx);

--- a/src/main/resources/localstack/s3/admins/admins.json
+++ b/src/main/resources/localstack/s3/admins/admins.json
@@ -32,5 +32,18 @@
     "key_hash": "IPoSHQMXtfpoxKufqh+ircEP6RFv6PqeAkLPWwdyuqPIe1OygfaBkgnGAlndFVXQ4GR0nSD8q+EQ8IU1tenbAA==",
     "key_salt": "MgCO9EvPIWaPLGWPrpYQn8++48yAN6KeBqHb/Vwg9e0=",
     "key_id": "ADLCL"
+  },
+  {
+    "key": "UID2-A-L-j16SQ6.RGqfzjpwfHFUQ9aQeRr+TPUkAhxrf0zb4JCIo=",
+    "name": "portal@example.com",
+    "contact": "portal@example.com",
+    "created": 1700695747,
+    "roles": [
+      "SHARING_PORTAL"
+    ],
+    "key_hash": "rsfDg8DKIIu8WGY/0KrYrWxzD/ZRpD0b+TrrMeoBCRVxSv2AeWg9w4SDNTbbXMfGhq42mTRMwvJ79eqMw0oshQ==",
+    "disabled": false,
+    "key_salt": "x9HDX9G2Z7J1pPLRtlx7oKOpEvCnr6ze4Vt+Kuzw0cQ=",
+    "key_id": "UID2-A-L-j16SQ"
   }
 ]

--- a/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
@@ -233,7 +233,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
 
     @Test
     void addKeypair(Vertx vertx, VertxTestContext testContext) throws Exception {
-        fakeAuth(Role.ADMINISTRATOR);
+        fakeAuth(Role.SHARING_PORTAL);
 
         Map<String, ClientSideKeypair> expectedKeypairs = new HashMap<>() {{
             put("89aZ234567", new ClientSideKeypair("89aZ234567", pub1, priv1, 124, "test-two@example.com", Instant.now(), true, name1));


### PR DESCRIPTION
- Allow users with `Role.SHARING_PORTAL` to call `/api/client_side_keypairs/add`
- Add a local admin key that only has `SHARING_PORTAL` to be used for devs. The associated changed in the portal is in https://github.com/IABTechLab/uid2-self-serve-portal/pull/227