### PR TITLE
Fix clients json data for portal

### DIFF
--- a/src/main/resources/localstack/s3/core/clients/clients.json
+++ b/src/main/resources/localstack/s3/core/clients/clients.json
@@ -59,7 +59,8 @@
     "contact": "Publisher",
     "created": 1609459200,
     "roles": [
-      "GENERATOR"
+      "GENERATOR",
+      "ID_READER"
     ],
     "disabled": false,
     "site_id": 124,
@@ -90,7 +91,8 @@
     "contact": "Advertiser",
     "created": 1609459200,
     "roles": [
-      "MAPPER"
+      "MAPPER",
+      "SHARER"
     ],
     "disabled": false,
     "site_id": 126,


### PR DESCRIPTION
In the portal, we filter out sites that do not have the associated roles of `SHARER` or `ID_READER`, unless they are a DSP. This change adds these roles so that we have at least one example of an advertiser and publisher with the default dev setup.