### PR TITLE
Separating Contact and Name field for client keys

### DIFF
--- a/src/main/java/com/uid2/admin/legacy/LegacyClientKey.java
+++ b/src/main/java/com/uid2/admin/legacy/LegacyClientKey.java
@@ -122,11 +122,6 @@ public class LegacyClientKey implements IRoleAuthorizable<Role> {
         return this;
     }
 
-    public LegacyClientKey withNameAndContact(String name) {
-        this.name = this.contact = name;
-        return this;
-    }
-
     public long getCreated() {
         return created;
     }

--- a/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
@@ -486,16 +486,16 @@ public class ClientKeyService implements IService {
 
             List<LegacyClientKey> clients = getAllClientKeys();
 
-            LegacyClientKey c = existingClient.get();
-            c.withContact(newContact);
+            LegacyClientKey existingClientObject = existingClient.get();
+            existingClientObject.withContact(newContact);
 
             // upload to storage
             storeWriter.upload(clients, null);
 
-            this.keysetManager.createKeysetForClient(c.toClientKey());
+            this.keysetManager.createKeysetForClient(existingClientObject.toClientKey());
 
             // return client with new key
-            rc.response().end(JSON_WRITER.writeValueAsString(c.toClientKey()));
+            rc.response().end(JSON_WRITER.writeValueAsString(existingClientObject.toClientKey()));
         } catch (Exception e) {
             rc.fail(500, e);
         }

--- a/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
@@ -242,13 +242,6 @@ public class ClientKeyService implements IService {
             clientKeyProvider.loadContent(clientKeyProvider.getMetadata());
 
             final String name = rc.queryParam("name").get(0);
-            Optional<LegacyClientKey> existingClient = this.clientKeyProvider.getAll()
-                    .stream().filter(c -> c.getName().equals(name))
-                    .findFirst();
-            if (existingClient.isPresent()) {
-                ResponseUtil.error(rc, 400, "key existed");
-                return;
-            }
 
             Set<Role> roles = RequestUtil.getRoles(rc.queryParam("roles").get(0));
             if (roles == null) {
@@ -279,7 +272,7 @@ public class ClientKeyService implements IService {
                     khr.getSalt(),
                     secret,
                     name,
-                    name,
+                    site.getName() + '_' + keyId,
                     created.getEpochSecond(),
                     roles,
                     site.getId(),

--- a/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
@@ -86,7 +86,7 @@ public class ClientKeyService implements IService {
             synchronized (writeLock) {
                 this.handleClientAdd(ctx);
             }
-        }, Role.CLIENTKEY_ISSUER));
+        }, Role.CLIENTKEY_ISSUER, Role.SHARING_PORTAL));
 
         router.post("/api/client/del").blockingHandler(auth.handle((ctx) -> {
             synchronized (writeLock) {

--- a/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/ClientKeyService.java
@@ -204,9 +204,9 @@ public class ClientKeyService implements IService {
 
     private void handleClientReveal(RoutingContext rc) {
         try {
-            final String name = rc.queryParam("name").get(0);
+            final String contact = rc.queryParam("contact").get(0);
             Optional<LegacyClientKey> existingClient = this.clientKeyProvider.getAll()
-                    .stream().filter(c -> c.getName().equals(name))
+                    .stream().filter(c -> c.getContact().equals(contact))
                     .findFirst();
             if (existingClient.isEmpty()) {
                 ResponseUtil.error(rc, 404, "client not found");
@@ -305,9 +305,9 @@ public class ClientKeyService implements IService {
             // refresh manually
             clientKeyProvider.loadContent(clientKeyProvider.getMetadata());
 
-            final String name = rc.queryParam("name").get(0);
+            final String contact = rc.queryParam("contact").get(0);
             Optional<LegacyClientKey> existingClient = this.clientKeyProvider.getAll()
-                    .stream().filter(c -> c.getName().equals(name))
+                    .stream().filter(c -> c.getContact().equals(contact))
                     .findFirst();
             if (existingClient.isEmpty()) {
                 ResponseUtil.error(rc, 404, "client key not found");
@@ -337,9 +337,9 @@ public class ClientKeyService implements IService {
             // refresh manually
             clientKeyProvider.loadContent(clientKeyProvider.getMetadata());
 
-            final String name = rc.queryParam("name").get(0);
+            final String contact = rc.queryParam("contact").get(0);
             final LegacyClientKey existingClient = this.clientKeyProvider.getAll()
-                    .stream().filter(c -> c.getName().equals(name))
+                    .stream().filter(c -> c.getContact().equals(contact))
                     .findFirst().orElse(null);
             if (existingClient == null) {
                 ResponseUtil.error(rc, 404, "client not found");
@@ -382,9 +382,9 @@ public class ClientKeyService implements IService {
             // refresh manually
             clientKeyProvider.loadContent(clientKeyProvider.getMetadata());
 
-            final String name = rc.queryParam("name").get(0);
+            final String contact = rc.queryParam("contact").get(0);
             Optional<LegacyClientKey> existingClient = this.clientKeyProvider.getAll()
-                    .stream().filter(c -> c.getName().equals(name))
+                    .stream().filter(c -> c.getContact().equals(contact))
                     .findFirst();
             if (existingClient.isEmpty()) {
                 ResponseUtil.error(rc, 404, "client key not found");
@@ -422,9 +422,9 @@ public class ClientKeyService implements IService {
             // refresh manually
             clientKeyProvider.loadContent(clientKeyProvider.getMetadata());
 
-            final String name = rc.queryParam("name").get(0);
+            final String contact = rc.queryParam("contact").get(0);
             Optional<LegacyClientKey> existingClient = this.clientKeyProvider.getAll()
-                    .stream().filter(c -> c.getName().equals(name))
+                    .stream().filter(c -> c.getContact().equals(contact))
                     .findFirst();
             if (existingClient.isEmpty()) {
                 ResponseUtil.error(rc, 404, "client not found");
@@ -459,24 +459,17 @@ public class ClientKeyService implements IService {
             // refresh manually
             clientKeyProvider.loadContent(clientKeyProvider.getMetadata());
 
-            final String oldName = rc.queryParam("oldName").get(0);
+            final String contact = rc.queryParam("contact").get(0);
             final String newName = rc.queryParam("newName").get(0);
             final LegacyClientKey existingClient = this.clientKeyProvider.getAll()
-                    .stream().filter(c -> c.getName().equals(oldName))
+                    .stream().filter(c -> c.getContact().equals(contact))
                     .findFirst().orElse(null);
             if (existingClient == null) {
                 ResponseUtil.error(rc, 404, "client not found");
                 return;
             }
-            final LegacyClientKey existingClientWithNewName = this.clientKeyProvider.getAll()
-                    .stream().filter(c -> c.getName().equals(newName))
-                    .findFirst().orElse(null);
-            if (existingClientWithNewName != null) {
-                ResponseUtil.error(rc, 400, "already exist a client with name " + newName);
-                return;
-            }
 
-            existingClient.withNameAndContact(newName);
+            existingClient.withName(newName);
 
             List<LegacyClientKey> clients = getAllClientKeys();
 

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -284,7 +284,6 @@ public class ClientKeyServiceTest extends ServiceTestBase {
             );
             testContext.completeNow();
         });
-
     }
 
     @Test
@@ -297,7 +296,6 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         );
 
         post(vertx, testContext, "api/client/contact?oldContact=test_contact&newContact=test_contact1", "", expectHttpStatus(testContext, 400));
-
     }
 
     private static void assertAddedClientKeyEquals(ClientKey expected, ClientKey actual) {

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -51,7 +51,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
 
-        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", response -> {
+        post(vertx, testContext, "api/client/rename?contact=test_contact&newName=test_client1", "", response -> {
             ClientKey expected = new LegacyClientBuilder().withName("test_client1").build().toClientKey();
             assertAll(
                     "clientRename",
@@ -61,17 +61,6 @@ public class ClientKeyServiceTest extends ServiceTestBase {
             );
             testContext.completeNow();
         });
-    }
-
-    @Test
-    public void clientRenameWithExistingName(Vertx vertx, VertxTestContext testContext) {
-        fakeAuth(Role.CLIENTKEY_ISSUER);
-        setClientKeys(
-                new LegacyClientBuilder().build(),
-                new LegacyClientBuilder().withName("test_client1").build()
-        );
-
-        post(vertx, testContext, "api/client/rename?oldName=test_client&newName=test_client1", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
@@ -147,7 +136,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().withServiceId(165).build());
 
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=999&service_id=200", "", response -> {
+        post(vertx, testContext, "api/client/update?contact=test_contact&site_id=999&service_id=200", "", response -> {
             ClientKey expected = new LegacyClientBuilder().withServiceId(200).build().toClientKey();
             assertAll(
                     "clientUpdate",
@@ -171,7 +160,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                         .build()
         );
 
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=999&service_id=145", "", response -> {
+        post(vertx, testContext, "api/client/update?contact=test_contact&site_id=999&service_id=145", "", response -> {
             assertAll(
                     "clientUpdateCreatesSiteKeyIfNoneExists",
                     () -> assertEquals(200, response.statusCode()),
@@ -189,28 +178,28 @@ public class ClientKeyServiceTest extends ServiceTestBase {
     @Test
     public void clientUpdateUnknownClientName(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=999", "", expectHttpStatus(testContext, 404));
+        post(vertx, testContext, "api/client/update?contact=test_contact&site_id=999", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
     public void clientUpdateUnknownSiteId(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=4", "", expectHttpStatus(testContext, 404));
+        post(vertx, testContext, "api/client/update?contact=test_contact&site_id=4", "", expectHttpStatus(testContext, 404));
     }
 
     @Test
     public void clientUpdateSpecialSiteId1(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=1", "", expectHttpStatus(testContext, 400));
+        post(vertx, testContext, "api/client/update?contact=test_contact&site_id=1", "", expectHttpStatus(testContext, 400));
     }
 
     @Test
     public void clientUpdateSpecialSiteId2(Vertx vertx, VertxTestContext testContext) {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
-        post(vertx, testContext, "api/client/update?name=test_client&site_id=2", "", expectHttpStatus(testContext, 400));
+        post(vertx, testContext, "api/client/update?contact=test_contact&site_id=2", "", expectHttpStatus(testContext, 400));
     }
 
     @ParameterizedTest
@@ -219,7 +208,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         fakeAuth(Role.CLIENTKEY_ISSUER);
         setClientKeys(new LegacyClientBuilder().build());
 
-        String endpoint = String.format("api/client/roles?name=test_client&roles=%s", RequestUtil.getRolesSpec(roles));
+        String endpoint = String.format("api/client/roles?contact=test_contact&roles=%s", RequestUtil.getRolesSpec(roles));
         post(vertx, testContext, endpoint, "", response -> {
             assertAll(
                     "createSiteKeyIfNoneExistsTestData",
@@ -289,6 +278,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
 
     private static class LegacyClientBuilder {
         private String name = "test_client";
+        private String contact = "test_contact";
         private int siteId = 999;
         private Set<Role> roles = Set.of(Role.GENERATOR);
         private int serviceId = 0;
@@ -296,6 +286,11 @@ public class ClientKeyServiceTest extends ServiceTestBase {
 
         public LegacyClientBuilder withName(String name) {
             this.name = name;
+            return this;
+        }
+
+        public LegacyClientBuilder withContact(String contact) {
+            this.contact = contact;
             return this;
         }
 
@@ -326,7 +321,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
                     EXPECTED_CLIENT_KEY_SALT,
                     "",
                     name,
-                    name,
+                    contact,
                     0,
                     roles,
                     siteId,

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -298,6 +298,13 @@ public class ClientKeyServiceTest extends ServiceTestBase {
         post(vertx, testContext, "api/client/contact?oldContact=test_contact&newContact=test_contact1", "", expectHttpStatus(testContext, 400));
     }
 
+    @Test
+    public void setContactWithUnknownContact(Vertx vertx, VertxTestContext testContext) {
+        fakeAuth(Role.CLIENTKEY_ISSUER);
+
+        post(vertx, testContext, "api/client/contact?oldContact=test_contact&newContact=test_contact1", "", expectHttpStatus(testContext, 404));
+    }
+
     private static void assertAddedClientKeyEquals(ClientKey expected, ClientKey actual) {
         assertThat(actual)
                 .usingRecursiveComparison()

--- a/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientKeyServiceTest.java
@@ -283,7 +283,7 @@ public class ClientKeyServiceTest extends ServiceTestBase {
     private static void assertAddedClientKeyEquals(ClientKey expected, ClientKey actual) {
         assertThat(actual)
                 .usingRecursiveComparison()
-                .ignoringFields("secret", "secretBytes", "created")
+                .ignoringFields("secret", "secretBytes", "created", "contact")
                 .isEqualTo(expected);
     }
 

--- a/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
@@ -80,7 +80,6 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         assertArrayEquals(expectedKeypair.getPublicKey().getEncoded(), Base64.getDecoder().decode(resp.getString("public_key").substring(ClientSideKeypair.KEYPAIR_KEY_PREFIX_LENGTH)));
         assertArrayEquals(expectedKeypair.getPrivateKey().getEncoded(), Base64.getDecoder().decode(resp.getString("private_key").substring(ClientSideKeypair.KEYPAIR_KEY_PREFIX_LENGTH)));
         assertEquals(expectedKeypair.getSiteId(), resp.getInteger("site_id"));
-        assertEquals(expectedKeypair.getContact(), resp.getString("contact"));
         assertEquals(expectedKeypair.getCreated().getEpochSecond(), resp.getLong("created"));
         assertEquals(expectedKeypair.isDisabled(), resp.getBoolean("disabled"));
         assertEquals("UID2-X-L-", resp.getString("public_key").substring(0, ClientSideKeypair.KEYPAIR_KEY_PREFIX_LENGTH));

--- a/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/ClientSideKeypairServiceTest.java
@@ -80,6 +80,7 @@ public class ClientSideKeypairServiceTest extends ServiceTestBase {
         assertArrayEquals(expectedKeypair.getPublicKey().getEncoded(), Base64.getDecoder().decode(resp.getString("public_key").substring(ClientSideKeypair.KEYPAIR_KEY_PREFIX_LENGTH)));
         assertArrayEquals(expectedKeypair.getPrivateKey().getEncoded(), Base64.getDecoder().decode(resp.getString("private_key").substring(ClientSideKeypair.KEYPAIR_KEY_PREFIX_LENGTH)));
         assertEquals(expectedKeypair.getSiteId(), resp.getInteger("site_id"));
+        assertEquals(expectedKeypair.getContact(), resp.getString("contact"));
         assertEquals(expectedKeypair.getCreated().getEpochSecond(), resp.getLong("created"));
         assertEquals(expectedKeypair.isDisabled(), resp.getBoolean("disabled"));
         assertEquals("UID2-X-L-", resp.getString("public_key").substring(0, ClientSideKeypair.KEYPAIR_KEY_PREFIX_LENGTH));

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -13,11 +13,15 @@
 
 <h3>Search</h3>
 
-<label for="searchSiteId">Site Id:</label>
-<input type="text" id="searchSiteId" name="searchSiteId">
 
 <ul>
-    <li class="ro-cki" style="display: none"><a href="#" id="searchList">Search Keys by SiteId</a></li>
+    <li>
+        <form id="searchBySiteForm">
+            <label for="searchSiteId">Site Id:</label>
+            <input type="text" id="searchSiteId" name="searchSiteId">
+            <button type="button" id="searchList">Search Keys by SiteId</button>
+        </form>
+    </li>
     <li class="ro-cki" style="display: none"><a href="#" id="doList">List Client Keys</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doMeta">Get Metadata</a></li>
 </ul>

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -55,6 +55,10 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doRename">Rename Client Key</a></li>
 </ul>
 
+<h4>Low Level</h4>
+<ul>
+    <li class="ro-cki" style="display: none"><a href="#" id="doSetContact">Set Contact</a></li>
+</ul>
 
 <br>
 
@@ -163,6 +167,17 @@
             var clientContact = encodeURIComponent($('#clientContact').val());
             var newClientName = encodeURIComponent($('#clientName').val());
             var url = '/api/client/rename?contact=' + clientContact + '&newName=' + newClientName;
+            doApiCall('POST', url, '#standardOutput', '#errorOutput');
+        });
+
+        $('#doSetContact').on('click', function () {
+            var newClientContact = prompt("Enter the new contact", "new contact here");
+            var oldClientContact = encodeURIComponent($('#clientContact').val());
+
+            const confirmationMessage = `Confirm changing the contact to: ` + newClientContact;
+            if (!confirm(confirmationMessage)) return;
+
+            var url = '/api/client/contact?oldContact=' + oldClientContact + '&newContact=' + newClientContact;
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
 

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -18,6 +18,8 @@
 
 <ul>
     <li class="ro-cki" style="display: none"><a href="#" id="searchList">Search Keys by SiteId</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doList">List Client Keys</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doMeta">Get Metadata</a></li>
 </ul>
 
 <h3>Inputs</h3>
@@ -33,27 +35,26 @@
 <br>
 <br>
 
-<h3>Operations</h3>
+<h3>New Key</h3>
+<ul>
+    <li class="ro-cki" style="display: none"><a href="#" id="doAdd">Add Client Key</a></li>
+</ul>
+
+
+<h3>Operations on Existing Key</h3>
+
+<label for="clientContact">Contact:</label>
+<input type="text" id="clientContact" name="clientContact">
 
 <ul>
-    <li class="ro-cki" style="display: none"><a href="#" id="doMeta">Get Metadata</a></li>
-    <li class="ro-cki" style="display: none"><a href="#" id="doList">List Client Keys</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doReveal">Reveal Client Key</a></li>
-    <li class="ro-cki" style="display: none"><a href="#" id="doAdd">Add Client Key</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doDisable">Disable Client Key</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doEnable">Enable Client Key</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doSetRoles">Set Roles</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doSetSite">Update Site</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doRename">Rename Client Site</a></li>
 </ul>
 
-<br>
-
-<h3>Low Level Operations - Do Not Use Unless Necessary</h3>
-
-<ul>
-<!--    <li class="ro-adm" style="display: none"><a href="#" id="doDel">Delete Client Key</a></li>-->
-    <li class="ro-adm" style="display: none"><a href="#" id="doRename">Rename Client Key (Click to enter new client name)</a></li>
-</ul>
 
 <br>
 
@@ -84,8 +85,8 @@
         });
 
         $('#doReveal').on('click', function () {
-            var clientName = encodeURIComponent($('#clientName').val());
-            var url = '/api/client/reveal?name=' + clientName;
+            var clientContact = encodeURIComponent($('#clientContact').val());
+            var url = '/api/client/reveal?contact=' + clientContact;
 
             doApiCall('GET', url, '#standardOutput', '#errorOutput');
         });
@@ -105,50 +106,50 @@
                 return;
             }
 
-            var clientName = encodeURIComponent($('#clientName').val());
-            var url = '/api/client/del?name=' + clientName;
+            var clientContact = encodeURIComponent($('#clientContact').val());
+            var url = '/api/client/del?contact=' + clientContact;
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
 
         $('#doSetRoles').on('click', function () {
-            var clientName = encodeURIComponent($('#clientName').val());
+            var clientContact = encodeURIComponent($('#clientContact').val());
             var roles = encodeURIComponent($('#roles').val());
-            var url = '/api/client/roles?name=' + clientName + '&roles=' + roles;
+            var url = '/api/client/roles?contact=' + clientContact + '&roles=' + roles;
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
 
         $('#doSetSite').on('click', function () {
-            var clientName = encodeURIComponent($('#clientName').val());
+            var clientContact = encodeURIComponent($('#clientContact').val());
             var siteId = encodeURIComponent($('#siteId').val());
             var serviceId = encodeURIComponent($('#serviceId').val());
-            var url = '/api/client/update?name=' + clientName + '&site_id=' + siteId + '&service_id=' + serviceId;
+            var url = '/api/client/update?contact=' + clientContact + '&site_id=' + siteId + '&service_id=' + serviceId;
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
 
         $('#doDisable').on('click', function () {
-            const clientName = $('#clientName').val();
-            var encodedClientName = encodeURIComponent(clientName);
-            var url = '/api/client/disable?name=' + encodedClientName;
+            const clientContact = $('#clientContact').val();
+            var encodedClientContact = encodeURIComponent(clientContact);
+            var url = '/api/client/disable?contact=' + encodedClientContact;
     
-            if (!validateClientName(encodedClientName)) return;
+            if (!validateClientContact(encodedClientContact)) return;
 
-            const confirmationMessage = `Disabling this client key will prevent this key from generating UID2s in a server-side integration.\n\nBefore proceeding, ensure there is no valid traffic, and confirm that the participant has provided consent.\n\nAre you sure you want to disable ${clientName}?`;
+            const confirmationMessage = `Disabling this client key will prevent this key from generating UID2s in a server-side integration.\n\nBefore proceeding, ensure there is no valid traffic, and confirm that the participant has provided consent.\n\nAre you sure you want to disable ${clientContact}?`;
             if (!confirm(confirmationMessage)) return;
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
 
         $('#doEnable').on('click', function () {
-            const clientName = $('#clientName').val();
-            var encodedClientName = encodeURIComponent(clientName);
-            var url = '/api/client/enable?name=' + encodedClientName;
+            const clientContact = $('#clientContact').val();
+            var encodedClientContact = encodeURIComponent(clientContact);
+            var url = '/api/client/enable?contact=' + encodedClientContact;
 
-            if (!validateClientName(clientName)) return;
+            if (!validateClientContact(encodedClientContact)) return;
 
-            const confirmationMessage = `Enabling this client key will allow this key to generate UID2s in a server-side integration.\n\nAre you sure you want to enable ${clientName}?`;
+            const confirmationMessage = `Enabling this client key will allow this key to generate UID2s in a server-side integration.\n\nAre you sure you want to enable ${clientContact}?`;
             if (!confirm(confirmationMessage)) return;
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
@@ -159,15 +160,15 @@
                 return;
             }
 
-            var newClientName = prompt("Enter the new client name", "new client name here");
-            var oldClientName = encodeURIComponent($('#clientName').val());
-            var url = '/api/client/rename?oldName=' + oldClientName + '&newName=' + newClientName;
+            var clientContact = encodeURIComponent($('#clientContact').val());
+            var newClientName = encodeURIComponent($('#clientName').val());
+            var url = '/api/client/rename?contact=' + clientContact + '&newName=' + newClientName;
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
 
-        function validateClientName(clientName) {
-            if (!clientName) {
-                $('#errorOutput').text("required parameter: name")
+        function validateClientContact(clientContact) {
+            if (!clientContact) {
+                $('#errorOutput').text("required parameter: contact")
                 return false;
             }
             return true;

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -45,7 +45,7 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doDisable">Disable Client Key</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doEnable">Enable Client Key</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doSetRoles">Set Roles</a></li>
-    <li class="ro-cki" style="display: none"><a href="#" id="doSetSite">Update Site</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doSetSiteAndServiceId">Update Site ID and Service ID</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doRename">Rename Client Key</a></li>
 </ul>
 
@@ -121,7 +121,7 @@
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
 
-        $('#doSetSite').on('click', function () {
+        $('#doSetSiteAndServiceId').on('click', function () {
             var clientContact = encodeURIComponent($('#clientContact').val());
 
             var siteId = prompt("Enter the new siteId", "");
@@ -129,7 +129,7 @@
                 if (siteId === '') $('#errorOutput').html("Required Parameter: siteId");
                 return;
             }
-            var serviceId = prompt("Enter the new serviceId", "");
+            var serviceId = prompt("Enter the new serviceId", "0");
             if (!serviceId){
                 if (serviceId === '') $('#errorOutput').html("Required Parameter: serviceId");
                 return;

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -52,7 +52,7 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doEnable">Enable Client Key</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doSetRoles">Set Roles</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doSetSite">Update Site</a></li>
-    <li class="ro-cki" style="display: none"><a href="#" id="doRename">Rename Client Site</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doRename">Rename Client Key</a></li>
 </ul>
 
 

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -26,15 +26,15 @@
 
 <h3>Add Key</h3>
 <form id="addKeyForm">
-<label for="addClientName">Name:</label>
-<input type="text" id="addClientName" name="addClientName">
-<label for="addRoles">Roles:</label>
-<input type="text" id="addRoles" name="addRoles">
-<label for="addSiteId">Site Id:</label>
-<input type="text" id="addSiteId" name="addSiteId" value="1">
-<label for="addServiceId">Service Id:</label>
-<input type="text" id="addServiceId" name="addServiceId" value="0">
-<button type="button" id="doAdd">Add Client Key</button>
+    <label for="addClientName">Name:</label>
+    <input type="text" id="addClientName" name="addClientName">
+    <label for="addRoles">Roles:</label>
+    <input type="text" id="addRoles" name="addRoles">
+    <label for="addSiteId">Site Id:</label>
+    <input type="text" id="addSiteId" name="addSiteId" value="1">
+    <label for="addServiceId">Service Id:</label>
+    <input type="text" id="addServiceId" name="addServiceId" value="0">
+    <button type="button" id="doAdd">Add Client Key</button>
 </form>
 
 <h3>Edit Key</h3>

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -22,7 +22,7 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doMeta">Get Metadata</a></li>
 </ul>
 
-<h3>Inputs</h3>
+<h3>Operations</h3>
 
 <label for="clientName">Name:</label>
 <input type="text" id="clientName" name="clientName">
@@ -35,13 +35,13 @@
 <br>
 <br>
 
-<h3>New Key</h3>
+<h4>New Key</h4>
 <ul>
     <li class="ro-cki" style="display: none"><a href="#" id="doAdd">Add Client Key</a></li>
 </ul>
 
 
-<h3>Operations on Existing Key</h3>
+<h4>Existing Key</h4>
 
 <label for="clientContact">Contact:</label>
 <input type="text" id="clientContact" name="clientContact">
@@ -55,7 +55,7 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doRename">Rename Client Key</a></li>
 </ul>
 
-<h4>Low Level</h4>
+<h5>Low Level Operations - Do Not Use Unless Necessary</h5>
 <ul>
     <li class="ro-cki" style="display: none"><a href="#" id="doSetContact">Set Contact</a></li>
 </ul>

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -26,26 +26,26 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doMeta">Get Metadata</a></li>
 </ul>
 
-<h3>Operations</h3>
 
-<label for="clientName">Name:</label>
-<input type="text" id="clientName" name="clientName">
-<label for="roles">Roles:</label>
-<input type="text" id="roles" name="roles">
-<label for="siteId">Site Id:</label>
-<input type="text" id="siteId" name="siteId" value="1">
-<label for="serviceId">Service Id:</label>
-<input type="text" id="serviceId" name="serviceId" value="0">
-<br>
+
 <br>
 
-<h4>New Key</h4>
+<h3>New Key</h3>
+<label for="addClientName">Name:</label>
+<input type="text" id="addClientName" name="addClientName">
+<label for="addRoles">Roles:</label>
+<input type="text" id="addRoles" name="addRoles">
+<label for="addSiteId">Site Id:</label>
+<input type="text" id="addSiteId" name="addSiteId" value="1">
+<label for="addServiceId">Service Id:</label>
+<input type="text" id="addServiceId" name="addServiceId" value="0">
+<br>
 <ul>
     <li class="ro-cki" style="display: none"><a href="#" id="doAdd">Add Client Key</a></li>
 </ul>
 
 
-<h4>Existing Key</h4>
+<h3>Existing Key</h3>
 
 <label for="clientContact">Contact:</label>
 <input type="text" id="clientContact" name="clientContact">
@@ -100,10 +100,10 @@
         });
 
         $('#doAdd').on('click', function () {
-            var clientName = encodeURIComponent($('#clientName').val());
-            var roles = encodeURIComponent($('#roles').val());
-            var siteId = encodeURIComponent($('#siteId').val());
-            var serviceId = encodeURIComponent($('#serviceId').val());
+            var clientName = encodeURIComponent($('#addClientName').val());
+            var roles = encodeURIComponent($('#addRoles').val());
+            var siteId = encodeURIComponent($('#addSiteId').val());
+            var serviceId = encodeURIComponent($('#addServiceId').val());
             var url = '/api/client/add?name=' + clientName + '&roles=' + roles + '&site_id=' + siteId + '&service_id=' + serviceId;
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
@@ -122,7 +122,12 @@
 
         $('#doSetRoles').on('click', function () {
             var clientContact = encodeURIComponent($('#clientContact').val());
-            var roles = encodeURIComponent($('#roles').val());
+            var roles = prompt("Enter the new roles", "");
+            if (!roles){
+                if (roles === '') $('#errorOutput').html("Required Parameter: new roles");
+                return;
+            }
+
             var url = '/api/client/roles?contact=' + clientContact + '&roles=' + roles;
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
@@ -130,8 +135,18 @@
 
         $('#doSetSite').on('click', function () {
             var clientContact = encodeURIComponent($('#clientContact').val());
-            var siteId = encodeURIComponent($('#siteId').val());
-            var serviceId = encodeURIComponent($('#serviceId').val());
+
+            var siteId = prompt("Enter the new siteId", "");
+            if (!siteId){
+                if (siteId === '') $('#errorOutput').html("Required Parameter: siteId");
+                return;
+            }
+            var serviceId = prompt("Enter the new serviceId", "");
+            if (!serviceId){
+                if (serviceId === '') $('#errorOutput').html("Required Parameter: serviceId");
+                return;
+            }
+
             var url = '/api/client/update?contact=' + clientContact + '&site_id=' + siteId + '&service_id=' + serviceId;
 
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
@@ -164,18 +179,28 @@
         });
 
         $('#doRename').on('click', function () {
-            if (!confirm("Are you sure?")) {
+            var clientContact = encodeURIComponent($('#clientContact').val());
+            var newClientName = prompt("Enter the new name", "");
+            if (!newClientName){
+                if (newClientName === '') $('#errorOutput').html("Required Parameter: name");
                 return;
             }
 
-            var clientContact = encodeURIComponent($('#clientContact').val());
-            var newClientName = encodeURIComponent($('#clientName').val());
+            if (!confirm("Are you sure you want to rename the key to: " + newClientName)) {
+                return;
+            }
+
             var url = '/api/client/rename?contact=' + clientContact + '&newName=' + newClientName;
             doApiCall('POST', url, '#standardOutput', '#errorOutput');
         });
 
         $('#doSetContact').on('click', function () {
-            var newClientContact = prompt("Enter the new contact", "new contact here");
+            var newClientContact = prompt("Enter the new contact", "");
+            if (!newClientContact){
+                if (newClientContact === '') $('#errorOutput').html("Required Parameter: new contact");
+                return;
+            }
+
             var oldClientContact = encodeURIComponent($('#clientContact').val());
 
             const confirmationMessage = `Confirm changing the contact to: ` + newClientContact;

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -12,8 +12,6 @@
 <br>
 
 <h3>Search</h3>
-
-
 <ul>
     <li>
         <form id="searchBySiteForm">
@@ -26,11 +24,8 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doMeta">Get Metadata</a></li>
 </ul>
 
-
-
-<br>
-
-<h3>New Key</h3>
+<h3>Add Key</h3>
+<form id="addKeyForm">
 <label for="addClientName">Name:</label>
 <input type="text" id="addClientName" name="addClientName">
 <label for="addRoles">Roles:</label>
@@ -39,17 +34,12 @@
 <input type="text" id="addSiteId" name="addSiteId" value="1">
 <label for="addServiceId">Service Id:</label>
 <input type="text" id="addServiceId" name="addServiceId" value="0">
-<br>
-<ul>
-    <li class="ro-cki" style="display: none"><a href="#" id="doAdd">Add Client Key</a></li>
-</ul>
+<button type="button" id="doAdd">Add Client Key</button>
+</form>
 
-
-<h3>Existing Key</h3>
-
+<h3>Edit Key</h3>
 <label for="clientContact">Contact:</label>
 <input type="text" id="clientContact" name="clientContact">
-
 <ul>
     <li class="ro-cki" style="display: none"><a href="#" id="doReveal">Reveal Client Key</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doDisable">Disable Client Key</a></li>
@@ -59,12 +49,10 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doRename">Rename Client Key</a></li>
 </ul>
 
-<h5>Low Level Operations - Do Not Use Unless Necessary</h5>
+<h4>Low Level Operations - Do Not Use Unless Necessary</h4>
 <ul>
     <li class="ro-cki" style="display: none"><a href="#" id="doSetContact">Set Contact</a></li>
 </ul>
-
-<br>
 
 <h3>Output</h3>
 


### PR DESCRIPTION
Separating contact and name fields of clients keys. This way contact can be used for logging and is uniquely identifiably for TTD tracking while the name can be anything, allowing users to give keys names relevant to them. Names do not have to unique anymore. Contact will still be unique and is generated based on a combination of the site name and the keyId.

![chrome_BjxchURblE](https://github.com/IABTechLab/uid2-admin/assets/152250444/5de54358-47c6-4298-badc-01de07c3f1dc)
Changed layout of page for more logical flow, now each operation will have popups for the different information they need apart from contact.

![image](https://github.com/IABTechLab/uid2-admin/assets/152250444/4c6bfa9e-9701-4f1d-9f9e-706f7d44ef6d)
![image](https://github.com/IABTechLab/uid2-admin/assets/152250444/57854dbb-3fe6-48b7-9484-ee4bf8aae457)
Changing the contact of a key will require the new contact to be filled in in a new popup along with a second confirmation.