### PR TITLE
sch-UID2-2516-redirect-snowflake-etl-to-read-from-service-links-implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-admin</artifactId>
-    <version>4.5.10-SNAPSHOT</version>
+    <version>4.5.4-8f846ab080</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-admin</artifactId>
-    <version>4.5.4-8f846ab080</version>
+    <version>4.5.10-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -310,7 +310,7 @@ public class Main {
             DataStoreMetrics.addDataStoreMetrics("salt", saltProvider);
             DataStoreMetrics.addDataStoreMetrics("partners", partnerConfigProvider);
             DataStoreMetrics.addDataStoreMetrics("service_link", serviceLinkProvider);
-            DataStoreMetrics.addDataStoreSnowflakeMetrics("snowflake_service_link", serviceLinkProvider, serviceProvider);
+            DataStoreMetrics.addDataStoreServiceLinkEntryCount("snowflake", serviceLinkProvider, serviceProvider);
 
 
             ReplaceSharingTypesWithSitesJob replaceSharingTypesWithSitesJob = new ReplaceSharingTypesWithSitesJob(config, writeLock, adminKeysetProvider, keysetProvider, keysetStoreWriter, siteProvider);

--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -309,6 +309,9 @@ public class Main {
             DataStoreMetrics.addDataStoreMetrics("enclaves", enclaveIdProvider);
             DataStoreMetrics.addDataStoreMetrics("salt", saltProvider);
             DataStoreMetrics.addDataStoreMetrics("partners", partnerConfigProvider);
+            DataStoreMetrics.addDataStoreMetrics("service_link", serviceLinkProvider);
+            DataStoreMetrics.addDataStoreSnowflakeMetrics("snowflake_service_link", serviceLinkProvider, serviceProvider);
+
 
             ReplaceSharingTypesWithSitesJob replaceSharingTypesWithSitesJob = new ReplaceSharingTypesWithSitesJob(config, writeLock, adminKeysetProvider, keysetProvider, keysetStoreWriter, siteProvider);
             jobDispatcher.enqueue(replaceSharingTypesWithSitesJob);

--- a/src/main/java/com/uid2/admin/monitoring/DataStoreMetrics.java
+++ b/src/main/java/com/uid2/admin/monitoring/DataStoreMetrics.java
@@ -31,6 +31,8 @@ public final class DataStoreMetrics {
                 .builder("uid2_data_store_entry_count", () -> {
                     try {
                         // Warning: this downloads metadata from the underlying remote data store
+                        serviceStore.loadContent(serviceStore.getMetadata());
+                        serviceLinkStore.loadContent(serviceLinkStore.getMetadata());
                         Optional<Service> snowflakeService = serviceStore.getAllServices().stream().filter(s -> s.getName().equals("snowflake")).findFirst();
                         if (snowflakeService.isEmpty()) { throw new IllegalStateException("snowflake service does not exist, unable to find snowflake accounts"); }
                         long entryCount = serviceLinkStore.getAllServiceLinks().stream()

--- a/src/main/java/com/uid2/admin/monitoring/DataStoreMetrics.java
+++ b/src/main/java/com/uid2/admin/monitoring/DataStoreMetrics.java
@@ -1,7 +1,12 @@
 package com.uid2.admin.monitoring;
 
+import com.uid2.shared.model.Service;
 import com.uid2.shared.store.reader.IMetadataVersionedStore;
+import com.uid2.shared.store.reader.RotatingServiceLinkStore;
+import com.uid2.shared.store.reader.RotatingServiceStore;
 import io.micrometer.core.instrument.Gauge;
+
+import java.util.Optional;
 
 import static io.micrometer.core.instrument.Metrics.globalRegistry;
 
@@ -19,6 +24,25 @@ public final class DataStoreMetrics {
                 })
                 .tag("store", dataType)
                 .description("version from metadata of a data store")
+                .register(globalRegistry);
+    }
+    public static void addDataStoreSnowflakeMetrics(String dataType, RotatingServiceLinkStore serviceLinkStore, RotatingServiceStore serviceStore) {
+        Gauge
+                .builder("uid2_data_store_entry_count", () -> {
+                    try {
+                        // Warning: this downloads metadata from the underlying remote data store
+                        Optional<Service> snowflakeService = serviceStore.getAllServices().stream().filter(s -> s.getName().equals("snowflake")).findFirst();
+                        if (snowflakeService.isEmpty()) { throw new IllegalStateException("snowflake service does not exist, unable to find snowflake accounts"); }
+                        long entryCount = serviceLinkStore.getAllServiceLinks().stream()
+                                                                    .filter(s -> s.getServiceId() == snowflakeService.get().getServiceId())
+                                                                    .count();
+                        return entryCount;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .tag("store", dataType)
+                .description("entry count from metadata of a data store")
                 .register(globalRegistry);
     }
 }

--- a/src/main/java/com/uid2/admin/monitoring/DataStoreMetrics.java
+++ b/src/main/java/com/uid2/admin/monitoring/DataStoreMetrics.java
@@ -41,7 +41,7 @@ public final class DataStoreMetrics {
                                 .count();
                         return entryCount;
                     })
-                    .tag("store", serviceName.toLowerCase())
+                    .tag("store", serviceName.toLowerCase() + "_service_link")
                     .description("entry count of a data store")
                     .register(globalRegistry));
         } catch (Exception e) {

--- a/src/main/resources/localstack/s3/core/services/services.json
+++ b/src/main/resources/localstack/s3/core/services/services.json
@@ -5,7 +5,9 @@
     "name": "snowflake",
     "roles": [
       "MAPPER",
-      "SHARER"
+      "SHARER",
+      "ID_READER",
+      "GENERATOR"
     ]
   }
 ]


### PR DESCRIPTION
We'll be using uid2-admin to host the metrics for the snowflake account metadata and number of snowflake accounts. I've added a new data store method to retrieve the number of snowflake service links, and added a new data store for service link version.

I've also added the ID_READER and GENERATOR roles to the local snowflake service to reflect the roles required for the snowflake accounts. 