### PR TITLE
Support special characters in search

### DIFF
--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -81,7 +81,7 @@
     $(document).ready(function () {
 
         $('#searchSiteId').on('click', function () {
-            var siteId = encodeURIComponent($('#searchBySiteId').val())
+            var siteId = encodeURIComponent($('#searchBySiteId').val());
             if (!siteId) {
                 $('#errorOutput').html("Required Parameter: site_id")
                 return;

--- a/webroot/adm/client-key.html
+++ b/webroot/adm/client-key.html
@@ -81,27 +81,36 @@
     $(document).ready(function () {
 
         $('#searchSiteId').on('click', function () {
-            if(!$('#searchBySiteId').val()) {
+            var siteId = encodeURIComponent($('#searchBySiteId').val())
+            if (!siteId) {
                 $('#errorOutput').html("Required Parameter: site_id")
                 return;
             }
-            doApiCall('GET', '/api/client/list/' + $('#searchBySiteId').val(), '#standardOutput', '#errorOutput');
+            var url = `/api/client/list/${siteId}`;
+
+            doApiCall('GET', url, '#standardOutput', '#errorOutput');
         });
 
         $('#searchKeyId').on('click', function () {
-            if(!$('#searchByKeyId').val()) {
+            var keyId = encodeURIComponent($('#searchByKeyId').val());
+            if (!keyId) {
                 $('#errorOutput').html("Required Parameter: key_id")
                 return;
             }
-            doApiCall('GET', '/api/client/keyId?keyId=' + $('#searchByKeyId').val(), '#standardOutput', '#errorOutput');
+            var url = `/api/client/keyId?keyId=${keyId}`;
+
+            doApiCall('GET', url, '#standardOutput', '#errorOutput');
         });
 
         $('#searchContact').on('click', function () {
-            if(!$('#searchByContact').val()) {
+            var contact = encodeURIComponent($('#searchByContact').val());
+            if (!contact) {
                 $('#errorOutput').html("Required Parameter: contact")
                 return;
             }
-            doApiCall('GET', '/api/client/contact?contact=' + $('#searchByContact').val(), '#standardOutput', '#errorOutput');
+            var url = `/api/client/contact?contact=${contact}`;
+
+            doApiCall('GET', url, '#standardOutput', '#errorOutput');
         });
 
         $('#doMeta').on('click', function () {
@@ -173,7 +182,7 @@
         });
 
         $('#doDisable').on('click', function () {
-            const clientContact = $('#clientContact').val();
+            const clientContact = encodeURIComponent($('#clientContact').val());
             var encodedClientContact = encodeURIComponent(clientContact);
             var url = '/api/client/disable?contact=' + encodedClientContact;
     
@@ -186,7 +195,7 @@
         });
 
         $('#doEnable').on('click', function () {
-            const clientContact = $('#clientContact').val();
+            const clientContact = encodeURIComponent($('#clientContact').val());
             var encodedClientContact = encodeURIComponent(clientContact);
             var url = '/api/client/enable?contact=' + encodedClientContact;
 

--- a/webroot/adm/search.html
+++ b/webroot/adm/search.html
@@ -30,7 +30,7 @@
 <script language="JavaScript">
     $(document).ready(function () {
         $('#doSearch').on('click', function () {
-            var keyString = $('#key').val();
+            var keyString = encodeURIComponent($('#key').val());
             const url = '/api/search';
 
             doApiCallWithBody('POST', url, keyString, '#standardOutput', '#errorOutput');

--- a/webroot/adm/site.html
+++ b/webroot/adm/site.html
@@ -73,7 +73,7 @@
                 $('#errorOutput').html("Required Parameters: site_id")
                 return;
             }
-            var url = `/api/site/${siteId}`
+            var url = `/api/site/${siteId}`;
 
             doApiCall('GET', url, '#standardOutput', '#errorOutput');
         });

--- a/webroot/adm/site.html
+++ b/webroot/adm/site.html
@@ -68,11 +68,14 @@
     $(document).ready(function () {
 
         $('#searchList').on('click', function () {
-            if(!$('#searchSiteId').val()) {
+            var siteId = encodeURIComponent($('#searchSiteId').val());
+            if (!siteId) {
                 $('#errorOutput').html("Required Parameters: site_id")
                 return;
             }
-            doApiCall('GET', '/api/site/' + $('#searchSiteId').val(), '#standardOutput', '#errorOutput');
+            var url = `/api/site/${siteId}`
+
+            doApiCall('GET', url, '#standardOutput', '#errorOutput');
         });
 
         $('#doList').on('click', function () {


### PR DESCRIPTION
Some inputs were not encoded, so if they contained special characters (e.g. `+`, `&`) they would not be properly sent in the request and hence would return a 404.

Also included some minor formatting + syntax changes.

**Before**

![image](https://github.com/IABTechLab/uid2-admin/assets/137864392/b1f77653-3efe-43fc-af1f-00f05aafb9d7)

Note the `+` is cut off from the payload.

**After**

![image](https://github.com/IABTechLab/uid2-admin/assets/137864392/7138c05a-c194-48f5-9648-4c2f77a06aa9)

Note the `+` is properly encoded as `%2B`
