### PR TITLE
Remove encoding from secret search input

### DIFF
--- a/webroot/adm/search.html
+++ b/webroot/adm/search.html
@@ -30,7 +30,7 @@
 <script language="JavaScript">
     $(document).ready(function () {
         $('#doSearch').on('click', function () {
-            var keyString = encodeURIComponent($('#key').val());
+            var keyString = $('#key').val();
             const url = '/api/search';
 
             doApiCallWithBody('POST', url, keyString, '#standardOutput', '#errorOutput');


### PR DESCRIPTION
The input for the "Secret" search actually breaks when it is encoded, so reverting a change I made in https://github.com/IABTechLab/uid2-admin/pull/224