### PR TITLE
Address CVE-2024-28757 and CVE-2023-52425 vulnerabilities

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,5 +4,3 @@
 # e.g. 
 # CVE-2022-3996
 
-# https://atlassian.thetradedesk.com/jira/browse/UID2-2927
-CVE-2023-52425

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin@sha256:d7a82981336958683f147f17396fe2219cb1072a5853e8a8ef16d07f0535343a
+# sha from https://hub.docker.com/layers/amd64/eclipse-temurin/11.0.22_7-jre-alpine/images/sha256-d7a82981336958683f147f17396fe2219cb1072a5853e8a8ef16d07f0535343a?context=explore
+FROM eclipse-temurin@sha256:564eb67091b2cda82952299b4be52bf1b039289234b52f46057fe1286c173b71
 
 WORKDIR /app
 EXPOSE 8089

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-admin</artifactId>
-    <version>5.2.3-SNAPSHOT</version>
+    <version>5.2.5-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
- Update eclipse-temurin version
- This addresses `CVE-2024-28757` and `CVE-2023-52425`
- Successful run: https://github.com/IABTechLab/uid2-admin/actions/runs/8352156839/job/22861786259:
```
ghcr.io/iabtechlab/uid2-admin:5.2.5-SNAPSHOT-default (alpine 3.19.1)
====================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```