### PR TITLE
Disable writing Key ACLs

### DIFF
--- a/src/main/java/com/uid2/admin/vertx/service/KeyAclService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/KeyAclService.java
@@ -56,16 +56,17 @@ public class KeyAclService implements IService {
             }
         }, Role.PRIVILEGED));
 
-        router.post("/api/keys_acl/reset").blockingHandler(auth.handle((ctx) -> {
-            synchronized (writeLock) {
-                this.handleKeyAclReset(ctx);
-            }
-        }, Role.MAINTAINER));
-        router.post("/api/keys_acl/update").blockingHandler(auth.handle((ctx) -> {
-            synchronized (writeLock) {
-                this.handleKeyAclUpdate(ctx);
-            }
-        }, Role.MAINTAINER));
+//        UID2-2758 Disable setting Key ACLs
+//        router.post("/api/keys_acl/reset").blockingHandler(auth.handle((ctx) -> {
+//            synchronized (writeLock) {
+//                this.handleKeyAclReset(ctx);
+//            }
+//        }, Role.MAINTAINER));
+//        router.post("/api/keys_acl/update").blockingHandler(auth.handle((ctx) -> {
+//            synchronized (writeLock) {
+//                this.handleKeyAclUpdate(ctx);
+//            }
+//        }, Role.MAINTAINER));
     }
 
     private void handleRewriteMetadata(RoutingContext rc) {

--- a/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
+++ b/src/test/java/com/uid2/admin/vertx/KeyAclServiceTest.java
@@ -69,6 +69,7 @@ public class KeyAclServiceTest extends ServiceTestBase {
         });
     }
 
+/** UID2-2758 Disable setting Key ACLs
     @Test
     void keyAclResetNoAclToWhitelist(Vertx vertx, VertxTestContext testContext) throws Exception {
         fakeAuth(Role.MAINTAINER);
@@ -477,4 +478,5 @@ public class KeyAclServiceTest extends ServiceTestBase {
             testContext.completeNow();
         });
     }
+*/
 }

--- a/webroot/adm/key-acl.html
+++ b/webroot/adm/key-acl.html
@@ -4,13 +4,14 @@
     <script src="/js/main.js"></script>
 </head>
 <body>
-<h1>UID2 Admin - Key ACL Management</h1>
+<h1><b>Deprecated</b>: UID2 Admin - Key ACL Management</h1>
+
+<h2 style="color: red"><a href="https://atlassian.thetradedesk.com/jira/browse/UID2-2758">UID2-2758</a>: Key ACL entries must no longer be created. Read only by legacy operators now.</h2>
 
 <a href="/">Back</a>
 
-<br>
-<br>
 
+<!--
 <h3>Inputs</h3>
 
 <label for="siteId">Site Id:</label>
@@ -24,7 +25,7 @@
     <option value="whitelist">whitelist</option>
     <option value="blacklist">blacklist</option>
 </select>
-
+-->
 <br>
 <br>
 
@@ -32,8 +33,8 @@
 
 <ul>
     <li class="ro-cki" style="display: none"><a href="#" id="doList">List ACLs</a></li>
-    <li class="ro-cki" style="display: none"><a href="#" id="doReset">Reset ACL</a></li>
-    <li class="ro-cki" style="display: none"><a href="#" id="doUpdate">Update ACL</a></li>
+<!--    <li class="ro-cki" style="display: none"><a href="#" id="doReset">Reset ACL</a></li>-->
+<!--    <li class="ro-cki" style="display: none"><a href="#" id="doUpdate">Update ACL</a></li>-->
 </ul>
 
 <br>

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -30,7 +30,6 @@ Logged in as <span id="loginEmail"></span>
 
 <ul>
     <li class="ro-cki ro-adm" style="display: none"><a href="/adm/client-key.html">Client Key Management</a></li>
-    <li class="ro-cki ro-adm" style="display: none"><a href="/adm/key-acl.html">Encryption Key ACL Management</a></li>
     <li class="ro-adm" style="display: none"><a href="/adm/keysets.html">Keyset Access Management</a></li>
     <li class="ro-sem" style="display: none"><a href="/adm/encryption-key.html">Encryption Key Management</a></li>
     <li class="ro-sem" style="display: none"><a href="/adm/salt.html">Salts Management</a></li>
@@ -42,7 +41,10 @@ Logged in as <span id="loginEmail"></span>
     <li class="ro-adm" style="display: none"><a href="/adm/search.html">Key and Secret Search</a></li>
     <li class="ro-nil" style="display: none">No Admin Permissions</li>
 </ul>
-
-
+<br/>
+<h3>Deprecated</h3>
+<ul>
+    <li class="ro-cki ro-adm" style="display: none"><a href="/adm/key-acl.html">Encryption Key ACL Management</a></li>
+</ul>
 </body>
 </html>


### PR DESCRIPTION
1. Disable setting Key ACL and make it read only within the admin service GUI
2. Mark Key ACL overall deprecated and separate away from normal admin functionalities
3. Disabled Key ACL reset/update endpoints and related unit tests

See the below admin service page for the actual GUI changes.

## Main Admin Page
![image](https://github.com/IABTechLab/uid2-admin/assets/2499852/05321903-eba4-4b27-8cfc-42740d258eb0)

## Keys_ACL page
![image](https://github.com/IABTechLab/uid2-admin/assets/2499852/e1f2edfe-d4dd-4bb9-bd10-16a32759dceb)
