### PR TITLE
Fix Role Labels in oncall key creation page

### DIFF
--- a/webroot/adm/oncall/generate-api-key-secret.html
+++ b/webroot/adm/oncall/generate-api-key-secret.html
@@ -345,13 +345,13 @@
                                                     <input type="checkbox" id="createClient-workflow-roles-MAPPER"
                                                         class="form-check-input" name="createClient-workflow-roles[]"
                                                         value="MAPPER">
-                                                    <label for="createClient-workflow-roles-MAPPER">MAPPER - for publishers</label>
+                                                    <label for="createClient-workflow-roles-MAPPER">MAPPER - for advertisers, data providers</label>
                                                 </div>
                                                 <div class="form-check">
                                                     <input type="checkbox" id="createClient-workflow-roles-ID_READER"
                                                         class="form-check-input" name="createClient-workflow-roles[]"
                                                         value="ID_READER">
-                                                    <label for="createClient-workflow-roles-ID_READER">ID_READER - for advertisers, data providers</label>
+                                                    <label for="createClient-workflow-roles-ID_READER">ID_READER - for DSPs</label>
                                                 </div>
                                                 <div class="form-check pt-3 pb-2">
                                                     <input type="checkbox" class="form-check-input"


### PR DESCRIPTION
Current role labels are misleading
![admin-role-labels](https://github.com/user-attachments/assets/bacb9bbd-666d-4500-b5a2-d337e33785e1)
