### PR TITLE
Remove EXTRA_CONFIG build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,13 @@ EXPOSE 8089
 ARG JAR_NAME=uid2-admin
 ARG JAR_VERSION=1.0.0-SNAPSHOT
 ARG IMAGE_VERSION=1.0.0.unknownhash
-ARG EXTRA_CONFIG
 ENV JAR_NAME=${JAR_NAME}
 ENV JAR_VERSION=${JAR_VERSION}
 ENV IMAGE_VERSION=${IMAGE_VERSION}
 
 COPY ./target/${JAR_NAME}-${JAR_VERSION}-jar-with-dependencies.jar /app/${JAR_NAME}-${JAR_VERSION}.jar
 COPY ./target/${JAR_NAME}-${JAR_VERSION}-sources.jar /app
-COPY ./conf/default-config.json ${EXTRA_CONFIG} /app/conf/
+COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 COPY ./webroot/ /app/webroot/
 


### PR DESCRIPTION
This unused arg causes the entire build context to be copied to /app/conf, including 1.7G of Trivy cache files.