### PR TITLE
Basic preliminary refactoring to make sense of stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/*
 .idea/*
 .idea/
 *.iml
+.DS_Store

--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -288,7 +288,11 @@ public class Main {
             }
 
             synchronized (writeLock) {
-                cloudEncryptionKeyManager.generateKeysForOperators(operatorKeyProvider.getAll(), config.getLong("cloud_encryption_key_activates_in_seconds"), config.getInteger("cloud_encryption_key_count_per_site"));
+                cloudEncryptionKeyManager.generateKeysForOperators(
+                        operatorKeyProvider.getAll(),
+                        config.getLong("cloud_encryption_key_activates_in_seconds"),
+                        config.getInteger("cloud_encryption_key_count_per_site")
+                );
                 RotatingCloudEncryptionKeyProvider.loadContent();
             }
 


### PR DESCRIPTION
Bassic refactorings of CloudEncryptionKeyManager, should not have any changes in behavior:

1. Removed `public` from methods that aren't actually public
2. Moved the only actual public method to the top
3. Rearranged the logic to be a bit less nested, extracted a few helpers
4. Broken up really long lines that don't fit on my laptop monitor
5. Reduced repetition of common test data in the test