### PR TITLE
Serializing new salt fields

### DIFF
--- a/src/main/java/com/uid2/admin/store/writer/EncryptedSaltStoreWriter.java
+++ b/src/main/java/com/uid2/admin/store/writer/EncryptedSaltStoreWriter.java
@@ -43,7 +43,7 @@ public class EncryptedSaltStoreWriter extends SaltStoreWriter implements StoreWr
 
     @Override
     public void rewriteMeta() throws Exception {
-
+        // No rewrite_metadata endpoint for salts
     }
 
     @Override

--- a/src/main/java/com/uid2/admin/store/writer/SaltSerializer.java
+++ b/src/main/java/com/uid2/admin/store/writer/SaltSerializer.java
@@ -2,8 +2,6 @@ package com.uid2.admin.store.writer;
 
 import com.uid2.shared.model.SaltEntry;
 
-import java.util.List;
-
 public class SaltSerializer {
     public static String toCsv(SaltEntry[] entries) {
         StringBuilder stringBuilder = new StringBuilder();

--- a/src/main/java/com/uid2/admin/store/writer/SaltSerializer.java
+++ b/src/main/java/com/uid2/admin/store/writer/SaltSerializer.java
@@ -1,0 +1,56 @@
+package com.uid2.admin.store.writer;
+
+import com.uid2.shared.model.SaltEntry;
+
+import java.util.List;
+
+public class SaltSerializer {
+    public static String toCsv(SaltEntry[] entries) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (SaltEntry entry : entries) {
+            addLine(entry, stringBuilder);
+        }
+
+        return stringBuilder.toString();
+    }
+
+    private static void addLine(SaltEntry entry, StringBuilder stringBuilder) {
+        stringBuilder
+                .append(entry.id())
+                .append(",")
+                .append(entry.lastUpdated())
+                .append(",")
+                .append(entry.currentSalt());
+
+        stringBuilder.append(",");
+        stringBuilder.append(serializeNullable(entry.refreshFrom()));
+
+        stringBuilder.append(",");
+        stringBuilder.append(serializeNullable(entry.previousSalt()));
+
+        appendKey(stringBuilder, entry.currentKey());
+        appendKey(stringBuilder, entry.previousKey());
+
+        stringBuilder.append("\n");
+    }
+
+    private static void appendKey(StringBuilder stringBuilder, SaltEntry.KeyMaterial key) {
+        if (key != null) {
+            stringBuilder
+                    .append(",")
+                    .append(key.id())
+                    .append(",")
+                    .append(serializeNullable(key.key()))
+                    .append(",")
+                    .append(serializeNullable(key.salt()));
+        }
+        else  {
+            stringBuilder.append(",,,");
+        }
+    }
+
+    public static <T> String serializeNullable(T obj) {
+        return obj == null ? "" : obj.toString();
+    }
+}

--- a/src/main/java/com/uid2/admin/store/writer/SaltSerializer.java
+++ b/src/main/java/com/uid2/admin/store/writer/SaltSerializer.java
@@ -2,7 +2,7 @@ package com.uid2.admin.store.writer;
 
 import com.uid2.shared.model.SaltEntry;
 
-public class SaltSerializer {
+public final class SaltSerializer {
     private SaltSerializer() {}
 
     public static String toCsv(SaltEntry[] entries) {

--- a/src/main/java/com/uid2/admin/store/writer/SaltSerializer.java
+++ b/src/main/java/com/uid2/admin/store/writer/SaltSerializer.java
@@ -3,6 +3,8 @@ package com.uid2.admin.store.writer;
 import com.uid2.shared.model.SaltEntry;
 
 public class SaltSerializer {
+    private SaltSerializer() {}
+
     public static String toCsv(SaltEntry[] entries) {
         StringBuilder stringBuilder = new StringBuilder();
 

--- a/src/test/java/com/uid2/admin/store/writer/SaltSerializerTest.java
+++ b/src/test/java/com/uid2/admin/store/writer/SaltSerializerTest.java
@@ -1,0 +1,121 @@
+package com.uid2.admin.store.writer;
+
+import com.uid2.shared.model.SaltEntry;
+import com.uid2.shared.model.SaltEntry.KeyMaterial;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class SaltSerializerTest {
+    @Test
+    void toCsv_serializesNoSalts() {
+        var expected = "";
+
+        var salts = new SaltEntry[]{};
+        var actual = SaltSerializer.toCsv(salts);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toCsv_serializesSaltsWithNoOptionalFields() {
+        var expected = """
+1,100,salt1,,,,,,,,
+2,200,salt2,,,,,,,,
+""";
+
+        var salts = new SaltEntry[]{
+                new SaltEntry(1, "hashedId1", 100, "salt1", null, null, null, null),
+                new SaltEntry(2, "hashedId2", 200, "salt2", null, null, null, null),
+        };
+        var actual = SaltSerializer.toCsv(salts);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toCsv_serializesSaltsWithAllOptionalFields() {
+        var expected = """
+1,100,salt1,1000,previousSalt1,11,key1,keySalt1,111,key11,keySalt11
+2,200,salt2,2000,previousSalt2,22,key2,keySalt2,222,key22,keySalt22
+""";
+
+        var salts = new SaltEntry[]{
+                new SaltEntry(1,
+                        "hashedId1",
+                        100,
+                        "salt1",
+                        1000L,
+                        "previousSalt1",
+                        new KeyMaterial(11, "key1", "keySalt1"),
+                        new KeyMaterial(111, "key11", "keySalt11")
+                ),
+                new SaltEntry(2,
+                        "hashedId2",
+                        200,
+                        "salt2",
+                        2000L,
+                        "previousSalt2",
+                        new KeyMaterial(22, "key2", "keySalt2"),
+                        new KeyMaterial(222, "key22", "keySalt22")
+                ),
+        };
+        var actual = SaltSerializer.toCsv(salts);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toCsv_serializesSaltsWithV3IdentityMapFields() {
+        var expected = """
+1,100,salt1,1000,previousSalt1,,,,,,
+2,200,salt2,2000,previousSalt2,,,,,,
+""";
+
+        var salts = new SaltEntry[]{
+                new SaltEntry(1,
+                        "hashedId1",
+                        100,
+                        "salt1",
+                        1000L,
+                        "previousSalt1",
+                        null,
+                        null
+                ),
+                new SaltEntry(2,
+                        "hashedId2",
+                        200,
+                        "salt2",
+                        2000L,
+                        "previousSalt2",
+                        null,
+                        null
+                ),
+        };
+        var actual = SaltSerializer.toCsv(salts);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toCsv_toleratesNullsInKeys() {
+        var expected = """
+1,100,salt1,1000,previousSalt1,11,,,111,,
+""";
+
+        var salts = new SaltEntry[]{
+                new SaltEntry(1,
+                        "hashedId1",
+                        100,
+                        "salt1",
+                        1000L,
+                        "previousSalt1",
+                        new KeyMaterial(11, null, null),
+                        new KeyMaterial(111, null, null)
+                ),
+        };
+        var actual = SaltSerializer.toCsv(salts);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0a5f5e4e-15c5-4717-8d24-efb5cb75f0a9)
From the next salt rotation the new fields will be added empty to the salt file. (Test data above, not real salts)

![image](https://github.com/user-attachments/assets/cdd1bddc-3085-476a-b534-db1436aa030f)
Operator loads the salts with no code changes. 