### PR TITLE
sch-UID2-5352 honouring refresh from in salt rotation

### DIFF
--- a/conf/default-config.json
+++ b/conf/default-config.json
@@ -1,3 +1,4 @@
 {
-  "enable_keysets": false
+  "enable_keysets": false,
+  "enable_salt_rotation_refresh_from": false
 }

--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -12,7 +12,7 @@
   "keys_acl_metadata_path": "keys_acl/metadata.json",
   "salts_metadata_path": "salts/metadata.json",
   "salt_snapshot_location_prefix": "salts/salts.txt.",
-  "enable_salt_rotation_refresh_from": true,
+  "enable_salt_rotation_refresh_from": false,
   "operators_metadata_path": "operators/metadata.json",
   "enclaves_metadata_path": "enclaves/metadata.json",
   "partners_metadata_path": "partners/metadata.json",

--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -12,6 +12,7 @@
   "keys_acl_metadata_path": "keys_acl/metadata.json",
   "salts_metadata_path": "salts/metadata.json",
   "salt_snapshot_location_prefix": "salts/salts.txt.",
+  "enable_salt_rotation_refresh_from": true,
   "operators_metadata_path": "operators/metadata.json",
   "enclaves_metadata_path": "enclaves/metadata.json",
   "partners_metadata_path": "partners/metadata.json",

--- a/src/main/java/com/uid2/admin/AdminConst.java
+++ b/src/main/java/com/uid2/admin/AdminConst.java
@@ -5,4 +5,5 @@ public class AdminConst {
     public static final String ROLE_OKTA_GROUP_MAP_MAINTAINER = "role_okta_group_map_maintainer";
     public static final String ROLE_OKTA_GROUP_MAP_PRIVILEGED = "role_okta_group_map_privileged";
     public static final String ROLE_OKTA_GROUP_MAP_SUPER_USER = "role_okta_group_map_super_user";
+    public static final String ENABLE_SALT_ROTATION_REFRESH_FROM = "enable_salt_rotation_refresh_from";
 }

--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -232,7 +232,7 @@ public class Main {
             WriteLock writeLock = new WriteLock();
             KeyHasher keyHasher = new KeyHasher();
             IKeypairGenerator keypairGenerator = new SecureKeypairGenerator();
-            SaltRotation saltRotation = new SaltRotation(keyGenerator);
+            SaltRotation saltRotation = new SaltRotation(config, keyGenerator);
             EncryptionKeyService encryptionKeyService = new EncryptionKeyService(
                     config, auth, writeLock, encryptionKeyStoreWriter, keysetKeyStoreWriter, keyProvider, keysetKeysProvider, adminKeysetProvider, adminKeysetStoreWriter, keyGenerator, clock);
             KeysetManager keysetManager = new KeysetManager(

--- a/src/main/java/com/uid2/admin/secret/SaltRotation.java
+++ b/src/main/java/com/uid2/admin/secret/SaltRotation.java
@@ -6,8 +6,6 @@ import com.uid2.shared.store.salt.RotatingSaltProvider;
 
 import com.uid2.shared.store.salt.RotatingSaltProvider.SaltSnapshot;
 import io.vertx.core.json.JsonObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -26,7 +24,6 @@ public class SaltRotation {
     private final IKeyGenerator keyGenerator;
     private final boolean isRefreshFromEnabled;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SaltRotation.class);
     public SaltRotation(JsonObject config, IKeyGenerator keyGenerator) {
         this.keyGenerator = keyGenerator;
         this.isRefreshFromEnabled = config.getBoolean(ENABLE_REFRESH_FROM, false);

--- a/src/main/java/com/uid2/admin/secret/SaltRotation.java
+++ b/src/main/java/com/uid2/admin/secret/SaltRotation.java
@@ -1,5 +1,6 @@
 package com.uid2.admin.secret;
 
+import com.uid2.admin.AdminConst;
 import com.uid2.shared.model.SaltEntry;
 import com.uid2.shared.secret.IKeyGenerator;
 import com.uid2.shared.store.salt.RotatingSaltProvider;
@@ -18,7 +19,6 @@ import java.util.stream.IntStream;
 import static java.util.stream.Collectors.toList;
 
 public class SaltRotation {
-    private final static String ENABLE_REFRESH_FROM = "enable_salt_rotation_refresh_from";
     private final static long THIRTY_DAYS_IN_MS = Duration.ofDays(30).toMillis();
 
     private final IKeyGenerator keyGenerator;
@@ -26,7 +26,7 @@ public class SaltRotation {
 
     public SaltRotation(JsonObject config, IKeyGenerator keyGenerator) {
         this.keyGenerator = keyGenerator;
-        this.isRefreshFromEnabled = config.getBoolean(ENABLE_REFRESH_FROM, false);
+        this.isRefreshFromEnabled = config.getBoolean(AdminConst.ENABLE_SALT_ROTATION_REFRESH_FROM, false);
     }
 
     public Result rotateSalts(RotatingSaltProvider.SaltSnapshot lastSnapshot,

--- a/src/test/java/com/uid2/admin/secret/SaltRotationTest.java
+++ b/src/test/java/com/uid2/admin/secret/SaltRotationTest.java
@@ -252,7 +252,7 @@ public class SaltRotationTest {
     }
 
     @Test
-    void rotateSaltsRotateSaltsOnRefreshFromDate() throws Exception {
+    void rotateSaltsRotateWhenRefreshFromIsTargetDate() throws Exception {
         setup(true);
         final Duration[] minAges = {
                 Duration.ofDays(90),


### PR DESCRIPTION
Salts will only be considered for rotation if their refresh_from is equal to the target date. Feature is behind a feature switch, which can be enabled through the admin config file.

Unit test:
* salts that are old enough to rotate and are refreshing on target date will be considered for rotation
* salts that not old enough to rotate and are refreshing on the target date are not rotated
* salts that are old enough to rotate but are not refreshing on target date are not rotated
* refresh_from dates are updated appropriately