### PR TITLE
Add the ability to delete client-side keypairs

### DIFF
--- a/src/main/java/com/uid2/admin/vertx/Endpoints.java
+++ b/src/main/java/com/uid2/admin/vertx/Endpoints.java
@@ -22,6 +22,7 @@ public enum Endpoints {
 
     API_CLIENT_SIDE_KEYPAIRS_ADD("/api/client_side_keypairs/add"),
     API_CLIENT_SIDE_KEYPAIRS_UPDATE("/api/client_side_keypairs/update"),
+    API_CLIENT_SIDE_KEYPAIRS_DELETE("/api/client_side_keypairs/delete"),
     API_CLIENT_SIDE_KEYPAIRS_LIST("/api/client_side_keypairs/list"),
     API_CLIENT_SIDE_KEYPAIRS_SUBSCRIPTIONID("/api/client_side_keypairs/:subscriptionId"),
     API_CLIENT_SIDE_KEYPAIRS_BY_SITE("/api/v2/sites/:siteId/client-side-keypairs"),

--- a/webroot/adm/client-side-keypair.html
+++ b/webroot/adm/client-side-keypair.html
@@ -33,6 +33,7 @@
     <li class="ro-sem" style="display: none"><a href="#" id="doListSubscription">Reveal Keypair By Subscription Id</a></li>
     <li class="ro-sem" style="display: none"><a href="#" id="doCreate">Create Keypair</a></li>
     <li class="ro-sem" style="display: none"><a href="#" id="doUpdate">Update Keypair</a></li>
+    <li class="ro-sem" style="display: none"><a href="#" id="doDelete">Delete Keypair</a></li>
 </ul>
 
 <br>
@@ -107,6 +108,20 @@
             }
 
             doApiCall('POST', '/api/client_side_keypairs/update', '#standardOutput', '#errorOutput', JSON.stringify(payload));
+        });
+
+        $('#doDelete').on('click', function () {
+            const subscriptionId = $('#subscriptionId').val();
+            if (!subscriptionId) {
+                $('#errorOutput').text("required parameters: subscription_id");
+                return;
+            }
+
+            if (!confirm(`Are you sure you want to delete ${subscriptionId}?`)) return;
+
+            const payload = {"subscription_id": subscriptionId};
+
+            doApiCall('POST', '/api/client_side_keypairs/delete', '#standardOutput', '#errorOutput', JSON.stringify(payload));
         });
 
     });


### PR DESCRIPTION
UI and output look like:
<img width="828" alt="keypairkeleteoutput" src="https://github.com/user-attachments/assets/c1dacdc9-af00-4713-be04-c4af4ce9bd6a" />

Asks for confirmation:
[
<img width="413" alt="keypairdeleteconfirm" src="https://github.com/user-attachments/assets/3e76631c-7245-4cf2-94a8-dab2f738fd81" />
](url)
