### PR TITLE
add link-id-regex field to services

### DIFF
--- a/src/main/java/com/uid2/admin/vertx/Endpoints.java
+++ b/src/main/java/com/uid2/admin/vertx/Endpoints.java
@@ -82,6 +82,7 @@ public enum Endpoints {
     API_SERVICE_ADD("/api/service/add"),
     API_SERVICE_UPDATE("/api/service/update"),
     API_SERVICE_DELETE("/api/service/delete"),
+    API_SERVICE_REMOVE_LINK_ID_REGEX("/api/service/remove-link-id-regex"),
 
     API_SHARING_LISTS("/api/sharing/lists"),
     API_SHARING_LIST_SITEID("/api/sharing/list/:siteId"),

--- a/src/main/java/com/uid2/admin/vertx/service/ServiceService.java
+++ b/src/main/java/com/uid2/admin/vertx/service/ServiceService.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.uid2.admin.vertx.Endpoints.*;
@@ -67,6 +68,11 @@ public class ServiceService implements IService {
                 this.handleDelete(ctx);
             }
         }, new AuditParams(Collections.emptyList(), List.of("service_id")), Role.SUPER_USER));
+        router.post(API_SERVICE_REMOVE_LINK_ID_REGEX.toString()).blockingHandler(auth.handle((ctx) -> {
+            synchronized (writeLock) {
+                this.handleRemoveLinkIdRegex(ctx);
+            }
+        }, new AuditParams(Collections.emptyList(), List.of("service_id")), Role.PRIVILEGED));
     }
 
     private void handleServiceListAll(RoutingContext rc) {
@@ -113,6 +119,7 @@ public class ServiceService implements IService {
             Integer siteId = body.getInteger("site_id");
             String name = body.getString("name");
             JsonArray rolesSpec = body.getJsonArray("roles");
+            String linkIdRegex = body.getString("link_id_regex");
             if (siteId == null || name == null || rolesSpec == null || rolesSpec.isEmpty()) {
                 ResponseUtil.error(rc, 400, "required parameters: site_id, name, roles");
                 return;
@@ -147,11 +154,22 @@ public class ServiceService implements IService {
                 return;
             }
 
+            if (linkIdRegex != null && !linkIdRegex.isEmpty() && !linkIdRegex.isBlank()) {
+                try {
+                    Pattern.compile(linkIdRegex);
+                } catch (Exception e) {
+                    ResponseUtil.error(rc, 400, "invalid parameter: link_id_regex; not a valid regex");
+                    return;
+                }
+            } else {
+                linkIdRegex = null;
+            }
+
             final List<Service> services = this.serviceProvider.getAllServices()
                     .stream().sorted(Comparator.comparingInt(Service::getServiceId))
                     .collect(Collectors.toList());
             final int serviceId = 1 + services.stream().mapToInt(Service::getServiceId).max().orElse(0);
-            Service service = new Service(serviceId, siteId, name, roles);
+            Service service = new Service(serviceId, siteId, name, roles, linkIdRegex);
 
             services.add(service);
 
@@ -163,20 +181,20 @@ public class ServiceService implements IService {
         }
     }
 
-    // Can update the site_id, name and roles
+    // Can update the site_id, name, roles, and link_id_regex
     private void handleUpdate(RoutingContext rc) {
         try {
-            JsonObject body = rc.body().asJsonObject();
-            if (body == null) {
-                ResponseUtil.error(rc, 400, "json payload required but not provided");
-                return;
-            }
-            Integer serviceId = body.getInteger("service_id");
-            Integer siteId = body.getInteger("site_id");
-            String name = body.getString("name");
+            JsonObject body = rc.body() != null ? rc.body().asJsonObject() : null;
+            Service service = findServiceFromRequest(rc);
+            if (service == null) return; // error already handled
+
+            
+            Integer siteId = body != null ? body.getInteger("site_id") : null;
+            String name = body != null ? body.getString("name") : null;
+            String linkIdRegex = body != null ? body.getString("link_id_regex") : null;
 
             JsonArray rolesSpec = null;
-            if (body.getString("roles") != null && !body.getString("roles").isEmpty()) {
+            if (body != null && body.getString("roles") != null && !body.getString("roles").isEmpty()) {
                 try {
                     rolesSpec = body.getJsonArray("roles");
                 } catch (ClassCastException c) {
@@ -185,16 +203,7 @@ public class ServiceService implements IService {
                 }
             }
 
-            if (serviceId == null) {
-                ResponseUtil.error(rc, 400, "required parameters: service_id");
-                return;
-            }
-
-            final Service service = serviceProvider.getService(serviceId);
-            if (service == null) {
-                ResponseUtil.error(rc, 404, "failed to find a service for service_id: " + serviceId);
-                return;
-            }
+            int serviceId = service.getServiceId();
 
             // check that this does not create a duplicate service
             if (siteHasService(siteId, name, serviceId)) {
@@ -226,6 +235,16 @@ public class ServiceService implements IService {
                 service.setRoles(roles);
             }
 
+            if (linkIdRegex != null && !linkIdRegex.isEmpty() && !linkIdRegex.isBlank()) {
+                try {
+                    Pattern.compile(linkIdRegex);
+                    service.setLinkIdRegex(linkIdRegex);
+                } catch (Exception e) {
+                    ResponseUtil.error(rc, 400, "invalid parameter: link_id_regex; not a valid regex");
+                    return;
+                }
+            }
+
             if (siteId != null && siteId != 0) {
                 service.setSiteId(siteId);
             }
@@ -234,10 +253,7 @@ public class ServiceService implements IService {
                 service.setName(name);
             }
 
-            final List<Service> services = this.serviceProvider.getAllServices()
-                    .stream().sorted(Comparator.comparingInt(Service::getServiceId))
-                    .collect(Collectors.toList());
-
+            List<Service> services = getSortedServices();
 
             storeWriter.upload(services, null);
 
@@ -248,40 +264,31 @@ public class ServiceService implements IService {
     }
 
     private void handleDelete(RoutingContext rc) {
-        final int serviceId;
-        JsonObject body = rc.body() != null ? rc.body().asJsonObject() : null;
-        if (body == null) {
-            ResponseUtil.error(rc, 400, "json payload required but not provided");
-            return;
-        }
-        serviceId = body.getInteger("service_id", -1);
-        if (serviceId == -1) {
-            ResponseUtil.error(rc, 400, "required parameters: service_id");
-            return;
-        }
+        Service service = findServiceFromRequest(rc);
+        if (service == null) return; // error already handled
 
         try {
-            serviceProvider.loadContent();
-
-            Service service = serviceProvider.getService(serviceId);
-            if (service == null) {
-                ResponseUtil.error(rc, 404, "failed to find a service for service_id: " + serviceId);
-                return;
-            }
-
-            final List<Service> services = this.serviceProvider.getAllServices()
-                    .stream().sorted(Comparator.comparingInt(Service::getServiceId))
-                    .collect(Collectors.toList());
-
+            List<Service> services = getSortedServices();
             services.remove(service);
-
             storeWriter.upload(services, null);
-
             rc.response().end(toJson(service).encodePrettily());
         } catch (Exception e) {
             ResponseUtil.errorInternal(rc, "Internal Server Error", e);
         }
+    }
 
+    private void handleRemoveLinkIdRegex(RoutingContext rc) {
+        Service service = findServiceFromRequest(rc);
+        if (service == null) return; // error already handled
+
+        try {
+            service.setLinkIdRegex(null);
+            List<Service> services = getSortedServices();
+            storeWriter.upload(services, null);
+            rc.response().end(toJson(service).encodePrettily());
+        } catch (Exception e) {
+            ResponseUtil.errorInternal(rc, "Internal Server Error", e);
+        }
     }
 
     private JsonObject toJson(Service s) {
@@ -290,6 +297,7 @@ public class ServiceService implements IService {
         jsonObject.put("site_id", s.getSiteId());
         jsonObject.put("name", s.getName());
         jsonObject.put("roles", s.getRoles());
+        jsonObject.put("link_id_regex", s.getLinkIdRegex());
         return jsonObject;
     }
 
@@ -301,5 +309,40 @@ public class ServiceService implements IService {
         return (siteId != null && siteId != 0 && name != null && !name.isEmpty())
                 && serviceProvider.getAllServices().stream().anyMatch(s -> s.getServiceId() != serviceId
                     && s.getSiteId() == siteId && s.getName().equals(name));
+    }
+
+    
+    private Service findServiceFromRequest(RoutingContext rc) {
+        JsonObject body = rc.body() != null ? rc.body().asJsonObject() : null;
+        if (body == null) {
+            ResponseUtil.error(rc, 400, "json payload required but not provided");
+            return null;
+        }
+
+        int serviceId = body.getInteger("service_id", -1);
+        if (serviceId == -1) {
+            ResponseUtil.error(rc, 400, "required parameters: service_id");
+            return null;
+        }
+
+        try {
+            serviceProvider.loadContent();
+            Service service = serviceProvider.getService(serviceId);
+            if (service == null) {
+                ResponseUtil.error(rc, 404, "failed to find a service for service_id: " + serviceId);
+                return null;
+            }
+            return service;
+        } catch (Exception e) {
+            ResponseUtil.errorInternal(rc, "Internal Server Error", e);
+            return null;
+        }
+    }
+
+    private List<Service> getSortedServices() {
+        return serviceProvider.getAllServices()
+                .stream()
+                .sorted(Comparator.comparingInt(Service::getServiceId))
+                .collect(Collectors.toList());
     }
 }

--- a/webroot/adm/service.html
+++ b/webroot/adm/service.html
@@ -22,6 +22,8 @@
     <input type="text" id="serviceName" name="serviceName">
     <label for="roles">Roles:</label>
     <input type="text" id="roles" name="roles">
+    <label for="linkIdRegex">Link Id Regex:</label>
+    <input type="text" id="linkIdRegex" name="linkIdRegex">
 </div>
 
 <br>
@@ -34,6 +36,7 @@
     <li class="ro-cki" style="display: none"><a href="#" id="doListByServiceId">Get Service By Service Id</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doAdd">Add Service (PRIVILEGED)</a></li>
     <li class="ro-cki" style="display: none"><a href="#" id="doUpdate">Update Service (PRIVILEGED)</a></li>
+    <li class="ro-cki" style="display: none"><a href="#" id="doRemoveLinkIdRegex">Remove Link Id Regex (PRIVILEGED)</a></li>
 </ul>
 
 <br>
@@ -87,8 +90,9 @@
             }
 
             const roles = ($('#roles').val()).replace(/\s+/g, '').split(',').filter( (value, _, __) => value !== "");
+            const linkIdRegex = $('#linkIdRegex').val()
 
-            doApiCall('POST', '/api/service/add', '#standardOutput', '#errorOutput', JSON.stringify({site_id: siteId, name: serviceName, roles: roles}));
+            doApiCall('POST', '/api/service/add', '#standardOutput', '#errorOutput', JSON.stringify({site_id: siteId, name: serviceName, roles: roles, link_id_regex: linkIdRegex}));
         });
 
         $('#doUpdate').on('click', function () {
@@ -98,10 +102,12 @@
                 return
             }
             const siteId = parseInt($('#siteId').val())
-            const serviceName = $('#serviceName').val()
-            const roles = ($('#roles').val()).replace(/\s+/g, '').split(',').filter( (value, _, __) => value !== "");
+            const serviceName = $('#serviceName').val();
+            let roles = ($('#roles').val()).replace(/\s+/g, '').split(',').filter( (value, _, __) => value !== "");
+            roles = roles.length > 0 ? roles : null;
+            const linkIdRegex = $('#linkIdRegex').val()
 
-            doApiCall('POST', '/api/service/update', '#standardOutput', '#errorOutput', JSON.stringify({service_id: serviceId, site_id: siteId, name: serviceName, roles: roles}));
+            doApiCall('POST', '/api/service/update', '#standardOutput', '#errorOutput', JSON.stringify({service_id: serviceId, site_id: siteId, name: serviceName, roles: roles, link_id_regex: linkIdRegex}));
         });
 
         $('#doDelete').on('click', function () {
@@ -116,6 +122,18 @@
             }
 
             doApiCall('POST', '/api/service/delete', '#standardOutput', '#errorOutput', JSON.stringify({service_id: serviceId}));
+        });
+
+        $('#doRemoveLinkIdRegex').on('click', function () {
+            if (!confirm("Are you sure you want to remove the link id regex?")) {
+                return;
+            }
+            const serviceId = parseInt($('#serviceId').val())
+            if(!serviceId) {
+                $('#errorOutput').text("required parameters: service_id")
+                return
+            }
+            doApiCall('POST', '/api/service/remove-link-id-regex', '#standardOutput', '#errorOutput', JSON.stringify({service_id: serviceId}));
         });
     });
 </script>


### PR DESCRIPTION
This adds the ability to edit update, and remove new field "link_id_regex" on Service objects.

Added new helpers to reduce duplication:
* findServiceFromRequest
* getSortedServices

This PR depends on this PR for a new version of shared: https://github.com/IABTechLab/uid2-shared/pull/475