### PR TITLE
upgrade vertx from 4.5.13 to 4.5.18 due to CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.18</vertx.version>
         <vertx-maven-plugin.version>1.0.22</vertx-maven-plugin.version>
         <vertx.verticle>com.uid2.admin.vertx.AdminVerticle</vertx.verticle>
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.12.2</micrometer.version>
         <junit-jupiter.version>5.11.2</junit-jupiter.version>
-        <uid2-shared.version>10.8.0</uid2-shared.version>
+        <uid2-shared.version>10.9.0</uid2-shared.version>
         <okta-jwt.version>0.5.10</okta-jwt.version>
         <image.version>${project.version}</image.version>
     </properties>


### PR DESCRIPTION
also upgrade uid2-shared to 10.9.0 which has same vertx upgrade.