### PR TITLE
UID2-6837: Upgrade Netty to 4.1.132.Final (CVE-2026-33870, CVE-2026-33871)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,9 @@
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.12.2</micrometer.version>
         <junit-jupiter.version>5.11.2</junit-jupiter.version>
-        <uid2-shared.version>11.1.91</uid2-shared.version>
+        <uid2-shared.version>11.4.16</uid2-shared.version>
         <okta-jwt.version>0.5.10</okta-jwt.version>
+        <netty.version>4.1.132.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>
 
@@ -35,6 +36,18 @@
             </snapshots>
         </repository>
     </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Summary
- Add Netty BOM 4.1.132.Final to fix CVE-2026-33870 (HTTP request smuggling, CVSS 7.5) and CVE-2026-33871 (HTTP/2 CONTINUATION flood DoS, CVSS 8.7)
- Update uid2-shared to 11.4.16 (which also includes the Netty fix)

## Test plan
- [ ] CI passes
- [ ] Verify Netty version resolves to 4.1.132.Final via `mvn dependency:tree`
- [ ] Healthcheck returns 200 in test/integ

🤖 Generated with [Claude Code](https://claude.com/claude-code)