### PR TITLE
UID2-1750: add explicit Lombok dependency (was relying on transitive)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
             <artifactId>lombok</artifactId>
             <version>1.18.34</version>
             <scope>provided</scope>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
             <version>${uid2-shared.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.34</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
             <version>${vertx.version}</version>
@@ -162,6 +169,13 @@
                     <source>21</source>
                     <target>21</target>
                     <release>21</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.34</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- Add Lombok 1.18.34 as `provided` + `optional` dependency explicitly in `pom.xml`
- Register Lombok as an explicit `annotationProcessorPath` in `maven-compiler-plugin`

## Why
uid2-admin uses Lombok annotations (`@Getter`, `@AllArgsConstructor`, `lombok.val` in 9 files) but was silently relying on Lombok leaking transitively from uid2-shared's incorrect `compile`-scope declaration. The companion PR IABTechLab/uid2-shared#610 fixes uid2-shared to declare Lombok as `provided`+`optional`, stopping the transitive leak. uid2-admin must therefore declare Lombok explicitly. See [UID2-1750](https://thetradedesk.atlassian.net/browse/UID2-1750).

## Test plan
- [x] `mvn compile` passes (151 source files, 0 errors)
- [x] `mvn test` passes (698 tests, 0 failures, 1 skipped)
- [x] `mvn dependency:tree | grep lombok` shows `provided` scope (not `compile`)

> Merge uid2-shared companion PR first, then this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)