### PR TITLE
UID2-6929: CVE-2026-40200 upgrade musl/musl-utils to 1.2.5-r23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 COPY ./webroot/ /app/webroot/
 
-RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 && adduser -D uid2-admin && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads
+RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils && adduser -D uid2-admin && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads
 USER uid2-admin
 
 CMD java \


### PR DESCRIPTION
## Summary

CVE-2026-40200 (HIGH): musl libc arbitrary code execution and denial of service vulnerability in `musl`/`musl-utils` 1.2.5-r21. Fixed in 1.2.5-r23.

Adds `musl musl-utils` to the existing `apk upgrade` in the Dockerfile so the patched packages are installed at image build time.