### PR TITLE
UID2-6799 Use ci-auto-merge environment in Release Admin Image workflow

### DIFF
--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -26,4 +26,5 @@ jobs:
       release_type: ${{ inputs.release_type }}
       vulnerability_severity: ${{ inputs.vulnerability_severity }}
       java_version: 21
+      merge_environment: 'ci-auto-merge'
     secrets: inherit

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -26,5 +26,5 @@ jobs:
       release_type: ${{ inputs.release_type }}
       vulnerability_severity: ${{ inputs.vulnerability_severity }}
       java_version: 21
-      merge_environment: 'ci-auto-merge'
+      merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit


### PR DESCRIPTION
- Use `ci-auto-merge` environment in `Release Admin Image` workflow
- This configured UID2SourceAdmin as the PR author/merger, which has permissions to merge PRs without approval

Related:
- https://github.com/UnifiedID2/uid2-okta-configuration/pull/156
- https://github.com/IABTechLab/uid2-shared-actions/pull/219