### PR TITLE
suppress CVE-2026-33846: gnutls DTLS heap overflow DoS in Alpine base image

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -23,13 +23,3 @@ CVE-2026-33846 exp:2026-11-05
 # jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API
 # See: UID2-6670
 GHSA-72hv-8253-57qq exp:2026-09-01
-
-# libexpat NULL pointer dereference in Alpine base image - not exploitable, our Java services do not use libexpat
-# Fixed in libexpat 2.7.5, not yet available in eclipse-temurin Alpine 3.23 base image
-# See: UID2-6806
-CVE-2026-32776 exp:2026-04-25
-
-# Trivy reports CVE-2026-32776 with transposed digits (32767 instead of 32776) - this is a known Trivy bug
-# See: https://github.com/aquasecurity/trivy/discussions/10412 and UID2-6806
-# This entry can be removed once Trivy fixes the typo
-CVE-2026-32767 exp:2026-04-25

--- a/.trivyignore
+++ b/.trivyignore
@@ -16,6 +16,8 @@ CVE-2026-1584 exp:2026-08-27
 # gnutls DoS vulnerability via DTLS zero-length record - not impactful as gnutls is not used by our Java service
 # See: UID2-7008
 CVE-2026-33845 exp:2026-11-04
+# gnutls DoS vulnerability via heap buffer overflow in DTLS handshake - not impactful as gnutls is not used by our Java service
+CVE-2026-33846 exp:2026-11-05
 
 # jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API
 # See: UID2-6670

--- a/.trivyignore
+++ b/.trivyignore
@@ -17,6 +17,7 @@ CVE-2026-1584 exp:2026-08-27
 # See: UID2-7008
 CVE-2026-33845 exp:2026-11-04
 # gnutls DoS vulnerability via heap buffer overflow in DTLS handshake - not impactful as gnutls is not used by our Java service
+# See: UID2-7012
 CVE-2026-33846 exp:2026-11-05
 
 # jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API


### PR DESCRIPTION
## Summary

- CVE-2026-33846 (HIGH) — GnuTLS Denial of Service via heap buffer overflow in DTLS handshake (gnutls 3.8.11-r0 → fixed in 3.8.13-r0 in Alpine)
- gnutls is present in the Alpine layer of the eclipse-temurin base image but is **not used** by our Java service — the JVM uses JSSE for TLS over TCP/HTTPS, not gnutls
- The DTLS attack vector (TLS over UDP) is not applicable to our services — confirmed by searching all source code, Dockerfiles, and dependency files
- Suppressed in \`.trivyignore\` with expiry **2026-11-05** (6 months)

## Impact assessment

gnutls is an OS-level Alpine package. Our Java services use the JVM's JSSE (Java Secure Socket Extension) for all TLS — gnutls is never called. No references to gnutls found anywhere in this repo's source, config, or dependencies. The attack requires a DTLS handshake, which our TCP/HTTPS services never perform.

## Test plan

- [ ] Vulnerability scan CI check passes on this PR