### PR TITLE
UID2-6764: enable SLSA provenance attestation

### DIFF
--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -29,6 +29,7 @@ jobs:
       pull-requests: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     with: 
       release_type: ${{ inputs.release_type }}
       vulnerability_severity: ${{ inputs.vulnerability_severity }}

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -22,6 +22,13 @@ on:
 jobs:
   Image:
     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-java-to-docker-versioned.yaml@v3
+    permissions:
+      contents: write
+      security-events: write
+      packages: write
+      pull-requests: write
+      id-token: write
+      attestations: write
     with: 
       release_type: ${{ inputs.release_type }}
       vulnerability_severity: ${{ inputs.vulnerability_severity }}

--- a/README.md
+++ b/README.md
@@ -203,3 +203,20 @@ const myMultiSelect = {
   defaultValue: ['OPTION_1']     // Array or comma-separated string
 }
 ```
+
+## Verifying image provenance
+
+Every non-snapshot image published by this repo's release workflow ships with a [SLSA v1.0](https://slsa.dev/spec/v1.0/) build-provenance attestation, signed by GitHub's [Sigstore](https://www.sigstore.dev/) instance via the OIDC identity of the [shared publish workflow](https://github.com/IABTechLab/uid2-shared-actions). The attestation cryptographically binds the image digest to the source commit, the signing workflow, and the runner that built it.
+
+To verify an image, install [`gh`](https://cli.github.com/) (≥ 2.49) and run:
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/iabtechlab/uid2-admin:<tag> \
+  --owner IABTechLab \
+  --signer-repo IABTechLab/uid2-shared-actions
+```
+
+A successful run prints `✓ Verification succeeded!` followed by the SLSA provenance fields — including `sourceRepositoryDigest` (the source commit), `workflow.path` (the signing workflow), and the runner identity.
+
+Snapshot tags (`-SNAPSHOT` suffix) deliberately skip attestation. `gh attestation verify` returns `no attestations found` against a snapshot — that's expected.


### PR DESCRIPTION
## Summary
Adds `id-token: write` and `attestations: write` to the publish job(s) so the shared workflow can sign image provenance after [uid2-shared-actions#228](https://github.com/IABTechLab/uid2-shared-actions/pull/228) merges and the `v3` float is promoted.

This change is additive and harmless before the shared-actions side lands — the permissions are granted but only used once `actions/attest@v4` runs from `v3`.

## Test plan
- [ ] After uid2-shared-actions#228 merges and `v3` is promoted, verify a real publish produces a signed attestation with `gh attestation verify oci://ghcr.io/iabtechlab/uid2-admin:<tag> --owner UnifiedID2`.

Linked: [UID2-6764](https://thetradedesk.atlassian.net/browse/UID2-6764)

🤖 Generated with [Claude Code](https://claude.com/claude-code)