### PR TITLE
UID2-7063: Emit salts_rotated_last_cycle Prometheus gauge

### DIFF
--- a/src/main/java/com/uid2/admin/Main.java
+++ b/src/main/java/com/uid2/admin/Main.java
@@ -14,6 +14,7 @@ import com.uid2.admin.legacy.LegacyClientKeyStoreWriter;
 import com.uid2.admin.legacy.RotatingLegacyClientKeyProvider;
 import com.uid2.admin.managers.KeysetManager;
 import com.uid2.admin.monitoring.DataStoreMetrics;
+import com.uid2.admin.monitoring.SaltRotationMetrics;
 import com.uid2.admin.salt.SaltRotation;
 import com.uid2.admin.secret.*;
 import com.uid2.admin.store.*;
@@ -329,6 +330,7 @@ public class Main {
             DataStoreMetrics.addDataStoreMetrics("service_link", serviceLinkProvider);
             DataStoreMetrics.addDataStoreServiceLinkEntryCount("snowflake", serviceLinkProvider, serviceProvider);
 
+            SaltRotationMetrics.register(Metrics.globalRegistry);
 
             ReplaceSharingTypesWithSitesJob replaceSharingTypesWithSitesJob = new ReplaceSharingTypesWithSitesJob(config, writeLock, adminKeysetProvider, keysetProvider, keysetStoreWriter, siteProvider);
             jobDispatcher.enqueue(replaceSharingTypesWithSitesJob);

--- a/src/main/java/com/uid2/admin/monitoring/SaltRotationMetrics.java
+++ b/src/main/java/com/uid2/admin/monitoring/SaltRotationMetrics.java
@@ -1,0 +1,29 @@
+package com.uid2.admin.monitoring;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class SaltRotationMetrics {
+    private static final AtomicLong lastRotatedSaltCount = new AtomicLong(-1);
+
+    public static void register(MeterRegistry registry) {
+        // Reports NaN until the first rotation completes, so the alert does not fire on cold start.
+        Gauge.builder("uid2_salts_rotated_last_cycle", lastRotatedSaltCount, SaltRotationMetrics::asGaugeValue)
+                .description("Number of salts rotated in the most recent successful salt rotation cycle")
+                .strongReference(true)
+                .register(registry);
+    }
+
+    public static void recordRotated(int count) {
+        lastRotatedSaltCount.set(count);
+    }
+
+    private static double asGaugeValue(AtomicLong ref) {
+        long value = ref.get();
+        return value < 0 ? Double.NaN : (double) value;
+    }
+
+    private SaltRotationMetrics() {}
+}

--- a/src/main/java/com/uid2/admin/salt/SaltRotation.java
+++ b/src/main/java/com/uid2/admin/salt/SaltRotation.java
@@ -1,6 +1,7 @@
 package com.uid2.admin.salt;
 
 import com.uid2.admin.AdminConst;
+import com.uid2.admin.monitoring.SaltRotationMetrics;
 import com.uid2.shared.model.SaltEntry;
 import com.uid2.shared.secret.IKeyGenerator;
 
@@ -63,6 +64,7 @@ public class SaltRotation {
         logSaltAges("rotated-salts", targetDate, saltsToRotate);
         logSaltAges("total-salts", targetDate, Arrays.asList(postRotationSalts));
         logBucketFormatCount(targetDate, postRotationSalts);
+        SaltRotationMetrics.recordRotated(saltsToRotate.size());
 
         var nextSnapshot = new SaltSnapshot(
                 nextEffective,

--- a/src/test/java/com/uid2/admin/salt/SaltRotationTest.java
+++ b/src/test/java/com/uid2/admin/salt/SaltRotationTest.java
@@ -3,10 +3,12 @@ package com.uid2.admin.salt;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.uid2.admin.AdminConst;
+import com.uid2.admin.monitoring.SaltRotationMetrics;
 import com.uid2.admin.salt.helper.SaltBuilder;
 import com.uid2.admin.salt.helper.SaltSnapshotBuilder;
 import com.uid2.shared.model.SaltEntry;
 import com.uid2.shared.secret.IKeyGenerator;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -438,6 +440,61 @@ class SaltRotationTest {
 
     private int countEntriesWithLastUpdated(SaltEntry[] entries, Instant lastUpdated) {
         return (int) Arrays.stream(entries).filter(e -> e.lastUpdated() == lastUpdated.toEpochMilli()).count();
+    }
+
+    @Test
+    void testRotateSaltsRecordsLastCycleMetric() throws Exception {
+        var registry = new SimpleMeterRegistry();
+        SaltRotationMetrics.register(registry);
+        SaltRotationMetrics.recordRotated(-1);
+
+        final Duration[] minAges = {
+                Duration.ofDays(1),
+                Duration.ofDays(2),
+        };
+        var lastSnapshot = SaltSnapshotBuilder.start()
+                .entries(10, daysEarlier(10), targetDate())
+                .build();
+
+        var result = saltRotation.rotateSalts(lastSnapshot, minAges, 0.2, targetDate());
+        assertTrue(result.hasSnapshot());
+
+        var rotatedCount = countEntriesWithLastUpdated(result.getSnapshot().getAllRotatingSalts(), result.getSnapshot().getEffective());
+        var gauge = registry.find("uid2_salts_rotated_last_cycle").gauge();
+        assertThat(gauge).isNotNull();
+        assertThat(gauge.value()).isEqualTo((double) rotatedCount);
+    }
+
+    @Test
+    void testRotateSaltsNoSnapshotLeavesMetricUnchanged() throws Exception {
+        var registry = new SimpleMeterRegistry();
+        SaltRotationMetrics.register(registry);
+        SaltRotationMetrics.recordRotated(42);
+
+        final Duration[] minAges = {
+                Duration.ofDays(1),
+                Duration.ofDays(2),
+        };
+        var lastSnapshot = SaltSnapshotBuilder.start()
+                .entries(10, targetDate(), targetDate())
+                .build();
+
+        var result = saltRotation.rotateSalts(lastSnapshot, minAges, 0.2, targetDate());
+        assertFalse(result.hasSnapshot());
+
+        var gauge = registry.find("uid2_salts_rotated_last_cycle").gauge();
+        assertThat(gauge.value()).isEqualTo(42.0);
+    }
+
+    @Test
+    void testSaltRotationMetricReportsNaNBeforeFirstRotation() {
+        var registry = new SimpleMeterRegistry();
+        SaltRotationMetrics.register(registry);
+        SaltRotationMetrics.recordRotated(-1);
+
+        var gauge = registry.find("uid2_salts_rotated_last_cycle").gauge();
+        assertThat(gauge).isNotNull();
+        assertThat(Double.isNaN(gauge.value())).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `uid2_salts_rotated_last_cycle`, a Micrometer gauge emitted by uid2-admin that records the count of salts rotated in the most recent successful salt rotation cycle.
- The gauge reports `NaN` until the first rotation completes, so any equality-based alert built on it does not fire on cold start.
- Wired up in `Main.setupMetrics` via `SaltRotationMetrics.register(Metrics.globalRegistry)`, alongside the existing `DataStoreMetrics` registrations. `SaltRotation.rotateSalts` calls `SaltRotationMetrics.recordRotated(saltsToRotate.size())` after a successful rotation; the metric is not touched when `rotateSalts` returns `noSnapshot` or when `rotateSaltsZero` runs (which rotates no salts by design).

## Why
Ticket: [UID2-7063](https://thetradedesk.atlassian.net/browse/UID2-7063).

The existing `P*.{PROD,INTEG}.Admin.Salt.UnexpectedSaltRotationVolume` alerts key off a Loki log query (`salt_count_type=rotated-salts`). That has produced false positives when log ingestion glitches (Alloy re-streams, Loki push failures). A Prometheus gauge is sampled at scrape time and immune to that class of issue.

## Follow-ups (not in this PR)
- The companion alert change is in [`uid2-monitoring-configuration#swi-UID2-7063`](https://github.com/UnifiedID2/uid2-monitoring-configuration/pulls?q=is%3Apr+head%3Aswi-UID2-7063). That PR should be merged **after** this one is deployed through integ → prod, so the metric exists by the time the alert switches to query it.
- The salt-rotation Grafana dashboard (`c58e015d-b1f3-4a66-8b32-0bef4149540e`) is managed in the Grafana UI, not as JSON in the monitoring repo. Adding a panel for the new metric needs to happen there (UID2 grafana.net, which auto-syncs to EUID).

## Test plan
- [x] `mvn test -Dtest=SaltRotationTest` — 37 tests pass (34 existing + 3 new)
- [x] `mvn test -Dtest='SaltRotationTest,SaltServiceTest,SaltSerializerTest,EncryptedSaltStoreWriterTest'` — 51 tests pass
- [x] `mvn compile` clean
- [ ] After merge + integ deploy: verify `uid2_salts_rotated_last_cycle{env="integ",application="uid2-admin"}` appears in Grafana Cloud and matches the count in the `salt_count_type=rotated-salts` log on the next rotation cycle
- [ ] After integ verification: promote to prod