### PR TITLE
UID2-7035/UID2-7297: .trivyignore cleanup + netty upgrade to 4.1.135.Final

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -21,4 +21,4 @@ GHSA-72hv-8253-57qq exp:2026-09-01
 # gateway) so anonymous external attackers cannot reach the netty epoll socket directly;
 # LB-level connection limits and idle timeouts further cap the blast radius. CVSS impact is
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
-CVE-2026-42577 exp:2026-06-08
+CVE-2026-42577 exp:2026-09-11

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <uid2-shared.version>11.4.16</uid2-shared.version>
         <okta-jwt.version>0.5.10</okta-jwt.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>
 


### PR DESCRIPTION
## Summary

Two changes bundled:

### 1. .trivyignore cleanup (UID2-7035)
Extends CVE-2026-42577 (netty-transport-native-epoll DoS) expiry from 2026-06-08 to **2026-09-11**, aligning with `uid2-core`, `uid2-operator`, and `uid2-optout` which were already extended under UID2-7035. Rationale unchanged: netty 4.1.x has no fix (only 4.2.13.Final+), service sits behind mTLS LB, CVSS impact is Availability only. Revisit on vert.x 5 migration.

### 2. netty upgrade 4.1.133.Final → 4.1.135.Final (UID2-7297)
Fixes four HIGH severity vulnerabilities detected by Trivy:
- **CVE-2026-44249, CVE-2026-45416** — `io.netty:netty-handler`
- **CVE-2026-45674, CVE-2026-47691** — `io.netty:netty-resolver-dns`

uid2-admin runs a netty server and these code paths are reachable. The fix is a patch-level upgrade within 4.1.x, fully compatible with vert.x 4.5.21. The `<netty.version>` property and netty-bom import in `dependencyManagement` ensures all netty artifacts upgrade consistently.

## Test plan

- [ ] Trivy vulnerability scan passes in CI (no HIGH/CRITICAL findings)
- [ ] All unit tests pass
- [ ] No new CVEs introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)