### PR TITLE
UID2-7456: Suppress CVE-2026-56131/56407/56408 (libexpat) in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -38,3 +38,13 @@ CVE-2026-54513 exp:2026-07-25
 # eclipse-temurin base image has not yet been rebuilt with it.
 # See: UID2-7376
 CVE-2026-2100 exp:2026-09-01
+
+# CVE-2026-56131 / CVE-2026-56407 / CVE-2026-56408 — libexpat stack exhaustion / integer overflows
+# in the Alpine base image. uid2-admin is a pure Java service; the JVM parses XML via the built-in
+# JAXP/Xerces implementation, not the native libexpat C library, and there are no JNI bindings or
+# native deps that call into libexpat, so the crafted-XML attack path is not reachable. Fixed in
+# Alpine v3.23 libexpat >= 2.8.2-r0; the pinned eclipse-temurin base image has not yet been rebuilt with it.
+# See: UID2-7456
+CVE-2026-56131 exp:2026-08-09
+CVE-2026-56407 exp:2026-08-09
+CVE-2026-56408 exp:2026-08-09


### PR DESCRIPTION
## UID2-7456: Suppress CVE-2026-56131 / CVE-2026-56407 / CVE-2026-56408 (libexpat) in .trivyignore

Trivy flagged three HIGH-severity CVEs in the Alpine system library **libexpat** (installed `2.8.1-r0`) shipped in the `eclipse-temurin:21-jre-alpine-3.23` base image:

- **CVE-2026-56131** – missing handler-call-depth limit (stack exhaustion / DoS)
- **CVE-2026-56407** – integer overflow in `doProlog`
- **CVE-2026-56408** – integer overflow in `copyString`

### Decision
Suppress in `.trivyignore` with a 1-month expiry (`exp:2026-08-09`).

### Rationale
Not exploitable in our context — libexpat is a native C XML parser; this service parses XML via the JVM's built-in JAXP/Xerces implementation (pure Java), with no JNI bindings or native dependencies that call into libexpat, so the crafted-XML attack path is not reachable. All three CVEs are fixed in Alpine v3.23 `libexpat >= 2.8.2-r0`; the suppression will be revisited when the pinned `eclipse-temurin` base image is rebuilt with the fixed package (at which point the entry can be removed).

Jira: https://thetradedesk.atlassian.net/browse/UID2-7456
