### PR TITLE
UID2-7557: suppress jackson-core GHSA-r7wm-3cxj-wff9 (async parser, not reachable)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -48,3 +48,9 @@ CVE-2026-2100 exp:2026-09-01
 CVE-2026-56131 exp:2026-08-09
 CVE-2026-56407 exp:2026-08-09
 CVE-2026-56408 exp:2026-08-09
+
+# jackson-core async parser maxNumberLength bypass (GHSA-r7wm-3cxj-wff9) - incomplete fix for
+# GHSA-72hv-8253-57qq. Not exploitable: services only use the synchronous ObjectMapper API, not
+# jackson-core's non-blocking/async parser. A jackson bump is also in flight via uid2-shared
+# (PR #631) and will flow on the next release. See: UID2-7557 (predecessor UID2-6670)
+GHSA-r7wm-3cxj-wff9 exp:2026-08-23


### PR DESCRIPTION
## Vulnerability suppression — jackson-core GHSA-r7wm-3cxj-wff9 (HIGH)

Async-parser `maxNumberLength` bypass (incomplete fix for GHSA-72hv-8253-57qq). **Not reachable**: this service parses JSON only via the synchronous `ObjectMapper` API, never jackson-core’s non-blocking/async parser — the same rationale under which the predecessor advisory was suppressed (UID2-6670). A jackson bump is also in flight via uid2-shared PR #631 and will flow on the next release, at which point this can be removed.

Suppressed in `.trivyignore` with expiry **2026-08-23**. Ticket: UID2-7557.